### PR TITLE
Add RefSeq Protein Accessions for Most Genes

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -49191,7 +49191,7 @@
           <speciesReference species="M_cpd00072_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14470"/>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01330"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn12635_c0" sboTerm="SBO:0000176" id="R_rxn12635_c0" name="RXN0-6974.c [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -71670,7 +71670,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14470" fbc:name="MASE_RS14470" fbc:label="G_MASE_RS14470"/>
       <fbc:geneProduct metaid="meta_G_MASE_RS17340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17340" fbc:name="MASE_RS17340" fbc:label="G_MASE_RS17340">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">

--- a/model.xml
+++ b/model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version2" sboTerm="SBO:0000624" level="3" version="1" fbc:required="false">
-  <model metaid="meta_atcc_genome.rast.mdl" fbc:strict="true">
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" xmlns:fbc="http://www.sbml.org/sbml/level3/version1/fbc/version2" metaid="meta_" sboTerm="SBO:0000624" level="3" version="1" fbc:required="false">
+  <model metaid="meta_" fbc:strict="true">
     <listOfUnitDefinitions>
       <unitDefinition id="mmol_per_gDW_per_hr">
         <listOfUnits>
@@ -57678,7 +57678,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12165"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn45996_c0" sboTerm="SBO:0000176" id="R_rxn45996_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn45996_c0" sboTerm="SBO:0000176" id="R_rxn45996_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn45996_c0">
@@ -57736,7 +57736,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00460"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn42230_c0" sboTerm="SBO:0000176" id="R_rxn42230_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn42230_c0" sboTerm="SBO:0000176" id="R_rxn42230_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn42230_c0">
@@ -58855,7 +58855,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00475"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn41896_c0" sboTerm="SBO:0000176" id="R_rxn41896_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn41896_c0" sboTerm="SBO:0000176" id="R_rxn41896_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn41896_c0">
@@ -58996,7 +58996,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10325"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn44539_c0" sboTerm="SBO:0000176" id="R_rxn44539_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn44539_c0" sboTerm="SBO:0000176" id="R_rxn44539_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn44539_c0">
@@ -59116,7 +59116,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12400"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn41452_c0" sboTerm="SBO:0000176" id="R_rxn41452_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn41452_c0" sboTerm="SBO:0000176" id="R_rxn41452_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn41452_c0">
@@ -59229,7 +59229,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04445"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn46694_c0" sboTerm="SBO:0000176" id="R_rxn46694_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn46694_c0" sboTerm="SBO:0000176" id="R_rxn46694_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn46694_c0">
@@ -59313,7 +59313,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10775"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn42709_c0" sboTerm="SBO:0000176" id="R_rxn42709_c0" name=" [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn42709_c0" sboTerm="SBO:0000176" id="R_rxn42709_c0" name="[c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn42709_c0">
@@ -59400,7 +59400,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07810"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn41683_c0" sboTerm="SBO:0000176" id="R_rxn41683_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn41683_c0" sboTerm="SBO:0000176" id="R_rxn41683_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn41683_c0">
@@ -59803,7 +59803,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02330"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn43581_c0" sboTerm="SBO:0000176" id="R_rxn43581_c0" name=" [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn43581_c0" sboTerm="SBO:0000176" id="R_rxn43581_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn43581_c0">
@@ -59944,7 +59944,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08595"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn43470_c0" sboTerm="SBO:0000176" id="R_rxn43470_c0" name=" [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn43470_c0" sboTerm="SBO:0000176" id="R_rxn43470_c0" name="[c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn43470_c0">
@@ -62225,928 +62225,11932 @@
       </fbc:objective>
     </fbc:listOfObjectives>
     <fbc:listOfGeneProducts>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08695" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08695" fbc:name="MASE_RS08695" fbc:label="G_MASE_RS08695"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17325" fbc:name="MASE_RS17325" fbc:label="G_MASE_RS17325"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02955" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02955" fbc:name="MASE_RS02955" fbc:label="G_MASE_RS02955"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00670" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00670" fbc:name="MASE_RS00670" fbc:label="G_MASE_RS00670"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14345" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14345" fbc:name="MASE_RS14345" fbc:label="G_MASE_RS14345"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09535" fbc:name="MASE_RS09535" fbc:label="G_MASE_RS09535"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09540" fbc:name="MASE_RS09540" fbc:label="G_MASE_RS09540"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07515" fbc:name="MASE_RS07515" fbc:label="G_MASE_RS07515"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12890" fbc:name="MASE_RS12890" fbc:label="G_MASE_RS12890"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07445" fbc:name="MASE_RS07445" fbc:label="G_MASE_RS07445"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00730" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00730" fbc:name="MASE_RS00730" fbc:label="G_MASE_RS00730"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10115" fbc:name="MASE_RS10115" fbc:label="G_MASE_RS10115"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11265" fbc:name="MASE_RS11265" fbc:label="G_MASE_RS11265"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14145" fbc:name="MASE_RS14145" fbc:label="G_MASE_RS14145"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11785" fbc:name="MASE_RS11785" fbc:label="G_MASE_RS11785"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11780" fbc:name="MASE_RS11780" fbc:label="G_MASE_RS11780"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10945" fbc:name="MASE_RS10945" fbc:label="G_MASE_RS10945"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11950" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11950" fbc:name="MASE_RS11950" fbc:label="G_MASE_RS11950"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03070" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03070" fbc:name="MASE_RS03070" fbc:label="G_MASE_RS03070"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15710" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15710" fbc:name="MASE_RS15710" fbc:label="G_MASE_RS15710"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09360" fbc:name="MASE_RS09360" fbc:label="G_MASE_RS09360"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05470" fbc:name="MASE_RS05470" fbc:label="G_MASE_RS05470"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12830" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12830" fbc:name="MASE_RS12830" fbc:label="G_MASE_RS12830"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18890" fbc:name="MASE_RS18890" fbc:label="G_MASE_RS18890"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06935" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06935" fbc:name="MASE_RS06935" fbc:label="G_MASE_RS06935"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12110" fbc:name="MASE_RS12110" fbc:label="G_MASE_RS12110"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13980" fbc:name="MASE_RS13980" fbc:label="G_MASE_RS13980"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16655" fbc:name="MASE_RS16655" fbc:label="G_MASE_RS16655"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13335" fbc:name="MASE_RS13335" fbc:label="G_MASE_RS13335"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00165" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00165" fbc:name="MASE_RS00165" fbc:label="G_MASE_RS00165"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16550" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16550" fbc:name="MASE_RS16550" fbc:label="G_MASE_RS16550"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08000" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08000" fbc:name="MASE_RS08000" fbc:label="G_MASE_RS08000"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08675" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08675" fbc:name="MASE_RS08675" fbc:label="G_MASE_RS08675"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05770" fbc:name="MASE_RS05770" fbc:label="G_MASE_RS05770"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02310" fbc:name="MASE_RS02310" fbc:label="G_MASE_RS02310"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07910" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07910" fbc:name="MASE_RS07910" fbc:label="G_MASE_RS07910"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02330" fbc:name="MASE_RS02330" fbc:label="G_MASE_RS02330"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03200" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03200" fbc:name="MASE_RS03200" fbc:label="G_MASE_RS03200"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08510" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08510" fbc:name="MASE_RS08510" fbc:label="G_MASE_RS08510"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09260" fbc:name="MASE_RS09260" fbc:label="G_MASE_RS09260"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12240" fbc:name="MASE_RS12240" fbc:label="G_MASE_RS12240"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01650" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01650" fbc:name="MASE_RS01650" fbc:label="G_MASE_RS01650"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13390" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13390" fbc:name="MASE_RS13390" fbc:label="G_MASE_RS13390"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12370" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12370" fbc:name="MASE_RS12370" fbc:label="G_MASE_RS12370"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04390" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04390" fbc:name="MASE_RS04390" fbc:label="G_MASE_RS04390"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15070" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15070" fbc:name="MASE_RS15070" fbc:label="G_MASE_RS15070"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11360" fbc:name="MASE_RS11360" fbc:label="G_MASE_RS11360"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09610" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09610" fbc:name="MASE_RS09610" fbc:label="G_MASE_RS09610"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07665" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07665" fbc:name="MASE_RS07665" fbc:label="G_MASE_RS07665"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17300" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17300" fbc:name="MASE_RS17300" fbc:label="G_MASE_RS17300"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05690" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05690" fbc:name="MASE_RS05690" fbc:label="G_MASE_RS05690"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05705" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05705" fbc:name="MASE_RS05705" fbc:label="G_MASE_RS05705"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08490" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08490" fbc:name="MASE_RS08490" fbc:label="G_MASE_RS08490"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16245" fbc:name="MASE_RS16245" fbc:label="G_MASE_RS16245"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00240" fbc:name="MASE_RS00240" fbc:label="G_MASE_RS00240"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16535" fbc:name="MASE_RS16535" fbc:label="G_MASE_RS16535"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19535" fbc:name="MASE_RS19535" fbc:label="G_MASE_RS19535"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08775" fbc:name="MASE_RS08775" fbc:label="G_MASE_RS08775"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11635" fbc:name="MASE_RS11635" fbc:label="G_MASE_RS11635"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19265" fbc:name="MASE_RS19265" fbc:label="G_MASE_RS19265"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06330" fbc:name="MASE_RS06330" fbc:label="G_MASE_RS06330"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04350" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04350" fbc:name="MASE_RS04350" fbc:label="G_MASE_RS04350"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11920" fbc:name="MASE_RS11920" fbc:label="G_MASE_RS11920"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11725" fbc:name="MASE_RS11725" fbc:label="G_MASE_RS11725"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14820" fbc:name="MASE_RS14820" fbc:label="G_MASE_RS14820"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02790" fbc:name="MASE_RS02790" fbc:label="G_MASE_RS02790"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13850" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13850" fbc:name="MASE_RS13850" fbc:label="G_MASE_RS13850"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03610" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03610" fbc:name="MASE_RS03610" fbc:label="G_MASE_RS03610"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02025" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02025" fbc:name="MASE_RS02025" fbc:label="G_MASE_RS02025"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19155" fbc:name="MASE_RS19155" fbc:label="G_MASE_RS19155"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09415" fbc:name="MASE_RS09415" fbc:label="G_MASE_RS09415"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14230" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14230" fbc:name="MASE_RS14230" fbc:label="G_MASE_RS14230"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05835" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05835" fbc:name="MASE_RS05835" fbc:label="G_MASE_RS05835"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14280" fbc:name="MASE_RS14280" fbc:label="G_MASE_RS14280"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01855" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01855" fbc:name="MASE_RS01855" fbc:label="G_MASE_RS01855"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15530" fbc:name="MASE_RS15530" fbc:label="G_MASE_RS15530"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12070" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12070" fbc:name="MASE_RS12070" fbc:label="G_MASE_RS12070"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17840" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17840" fbc:name="MASE_RS17840" fbc:label="G_MASE_RS17840"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02950" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02950" fbc:name="MASE_RS02950" fbc:label="G_MASE_RS02950"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12595" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12595" fbc:name="MASE_RS12595" fbc:label="G_MASE_RS12595"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12500" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12500" fbc:name="MASE_RS12500" fbc:label="G_MASE_RS12500"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06010" fbc:name="MASE_RS06010" fbc:label="G_MASE_RS06010"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12180" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12180" fbc:name="MASE_RS12180" fbc:label="G_MASE_RS12180"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09935" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09935" fbc:name="MASE_RS09935" fbc:label="G_MASE_RS09935"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09095" fbc:name="MASE_RS09095" fbc:label="G_MASE_RS09095"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09090" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09090" fbc:name="MASE_RS09090" fbc:label="G_MASE_RS09090"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09100" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09100" fbc:name="MASE_RS09100" fbc:label="G_MASE_RS09100"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09105" fbc:name="MASE_RS09105" fbc:label="G_MASE_RS09105"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19335" fbc:name="MASE_RS19335" fbc:label="G_MASE_RS19335"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15020" fbc:name="MASE_RS15020" fbc:label="G_MASE_RS15020"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04420" fbc:name="MASE_RS04420" fbc:label="G_MASE_RS04420"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19345" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19345" fbc:name="MASE_RS19345" fbc:label="G_MASE_RS19345"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09675" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09675" fbc:name="MASE_RS09675" fbc:label="G_MASE_RS09675"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04445" fbc:name="MASE_RS04445" fbc:label="G_MASE_RS04445"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12390" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12390" fbc:name="MASE_RS12390" fbc:label="G_MASE_RS12390"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00920" fbc:name="MASE_RS00920" fbc:label="G_MASE_RS00920"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00945" fbc:name="MASE_RS00945" fbc:label="G_MASE_RS00945"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17660" fbc:name="MASE_RS17660" fbc:label="G_MASE_RS17660"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01105" fbc:name="MASE_RS01105" fbc:label="G_MASE_RS01105"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06075" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06075" fbc:name="MASE_RS06075" fbc:label="G_MASE_RS06075"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14505" fbc:name="MASE_RS14505" fbc:label="G_MASE_RS14505"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18325" fbc:name="MASE_RS18325" fbc:label="G_MASE_RS18325"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14795" fbc:name="MASE_RS14795" fbc:label="G_MASE_RS14795"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11190" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11190" fbc:name="MASE_RS11190" fbc:label="G_MASE_RS11190"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19340" fbc:name="MASE_RS19340" fbc:label="G_MASE_RS19340"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09505" fbc:name="MASE_RS09505" fbc:label="G_MASE_RS09505"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16000" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16000" fbc:name="MASE_RS16000" fbc:label="G_MASE_RS16000"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16675" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16675" fbc:name="MASE_RS16675" fbc:label="G_MASE_RS16675"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03360" fbc:name="MASE_RS03360" fbc:label="G_MASE_RS03360"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03135" fbc:name="MASE_RS03135" fbc:label="G_MASE_RS03135"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00810" fbc:name="MASE_RS00810" fbc:label="G_MASE_RS00810"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03545" fbc:name="MASE_RS03545" fbc:label="G_MASE_RS03545"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08605" fbc:name="MASE_RS08605" fbc:label="G_MASE_RS08605"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08895" fbc:name="MASE_RS08895" fbc:label="G_MASE_RS08895"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03645" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03645" fbc:name="MASE_RS03645" fbc:label="G_MASE_RS03645"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10085" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10085" fbc:name="MASE_RS10085" fbc:label="G_MASE_RS10085"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00475" fbc:name="MASE_RS00475" fbc:label="G_MASE_RS00475"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17215" fbc:name="MASE_RS17215" fbc:label="G_MASE_RS17215"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10865" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10865" fbc:name="MASE_RS10865" fbc:label="G_MASE_RS10865"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09780" fbc:name="MASE_RS09780" fbc:label="G_MASE_RS09780"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03560" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03560" fbc:name="MASE_RS03560" fbc:label="G_MASE_RS03560"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07155" fbc:name="MASE_RS07155" fbc:label="G_MASE_RS07155"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07150" fbc:name="MASE_RS07150" fbc:label="G_MASE_RS07150"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04010" fbc:name="MASE_RS04010" fbc:label="G_MASE_RS04010"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06450" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06450" fbc:name="MASE_RS06450" fbc:label="G_MASE_RS06450"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06445" fbc:name="MASE_RS06445" fbc:label="G_MASE_RS06445"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06965" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06965" fbc:name="MASE_RS06965" fbc:label="G_MASE_RS06965"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09010" fbc:name="MASE_RS09010" fbc:label="G_MASE_RS09010"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00800" fbc:name="MASE_RS00800" fbc:label="G_MASE_RS00800"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16660" fbc:name="MASE_RS16660" fbc:label="G_MASE_RS16660"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06890" fbc:name="MASE_RS06890" fbc:label="G_MASE_RS06890"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03120" fbc:name="MASE_RS03120" fbc:label="G_MASE_RS03120"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14490" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14490" fbc:name="MASE_RS14490" fbc:label="G_MASE_RS14490"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05710" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05710" fbc:name="MASE_RS05710" fbc:label="G_MASE_RS05710"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08770" fbc:name="MASE_RS08770" fbc:label="G_MASE_RS08770"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07640" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07640" fbc:name="MASE_RS07640" fbc:label="G_MASE_RS07640"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12455" fbc:name="MASE_RS12455" fbc:label="G_MASE_RS12455"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07955" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07955" fbc:name="MASE_RS07955" fbc:label="G_MASE_RS07955"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02630" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02630" fbc:name="MASE_RS02630" fbc:label="G_MASE_RS02630"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07905" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07905" fbc:name="MASE_RS07905" fbc:label="G_MASE_RS07905"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11685" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11685" fbc:name="MASE_RS11685" fbc:label="G_MASE_RS11685"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07925" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07925" fbc:name="MASE_RS07925" fbc:label="G_MASE_RS07925"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03810" fbc:name="MASE_RS03810" fbc:label="G_MASE_RS03810"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19435" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19435" fbc:name="MASE_RS19435" fbc:label="G_MASE_RS19435"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07630" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07630" fbc:name="MASE_RS07630" fbc:label="G_MASE_RS07630"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05765" fbc:name="MASE_RS05765" fbc:label="G_MASE_RS05765"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02305" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02305" fbc:name="MASE_RS02305" fbc:label="G_MASE_RS02305"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08005" fbc:name="MASE_RS08005" fbc:label="G_MASE_RS08005"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11140" fbc:name="MASE_RS11140" fbc:label="G_MASE_RS11140"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10350" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10350" fbc:name="MASE_RS10350" fbc:label="G_MASE_RS10350"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13140" fbc:name="MASE_RS13140" fbc:label="G_MASE_RS13140"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05665" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05665" fbc:name="MASE_RS05665" fbc:label="G_MASE_RS05665"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13185" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13185" fbc:name="MASE_RS13185" fbc:label="G_MASE_RS13185"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09255" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09255" fbc:name="MASE_RS09255" fbc:label="G_MASE_RS09255"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09110" fbc:name="MASE_RS09110" fbc:label="G_MASE_RS09110"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09725" fbc:name="MASE_RS09725" fbc:label="G_MASE_RS09725"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07920" fbc:name="MASE_RS07920" fbc:label="G_MASE_RS07920"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01920" fbc:name="MASE_RS01920" fbc:label="G_MASE_RS01920"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04065" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04065" fbc:name="MASE_RS04065" fbc:label="G_MASE_RS04065"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18760" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18760" fbc:name="MASE_RS18760" fbc:label="G_MASE_RS18760"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18755" fbc:name="MASE_RS18755" fbc:label="G_MASE_RS18755"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16455" fbc:name="MASE_RS16455" fbc:label="G_MASE_RS16455"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01705" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01705" fbc:name="MASE_RS01705" fbc:label="G_MASE_RS01705"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05900" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05900" fbc:name="MASE_RS05900" fbc:label="G_MASE_RS05900"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10120" fbc:name="MASE_RS10120" fbc:label="G_MASE_RS10120"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16780" fbc:name="MASE_RS16780" fbc:label="G_MASE_RS16780"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07310" fbc:name="MASE_RS07310" fbc:label="G_MASE_RS07310"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05700" fbc:name="MASE_RS05700" fbc:label="G_MASE_RS05700"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13445" fbc:name="MASE_RS13445" fbc:label="G_MASE_RS13445"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13270" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13270" fbc:name="MASE_RS13270" fbc:label="G_MASE_RS13270"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10275" fbc:name="MASE_RS10275" fbc:label="G_MASE_RS10275"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00425" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00425" fbc:name="MASE_RS00425" fbc:label="G_MASE_RS00425"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10530" fbc:name="MASE_RS10530" fbc:label="G_MASE_RS10530"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08010" fbc:name="MASE_RS08010" fbc:label="G_MASE_RS08010"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10725" fbc:name="MASE_RS10725" fbc:label="G_MASE_RS10725"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00755" fbc:name="MASE_RS00755" fbc:label="G_MASE_RS00755"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00525" fbc:name="MASE_RS00525" fbc:label="G_MASE_RS00525"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02765" fbc:name="MASE_RS02765" fbc:label="G_MASE_RS02765"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02770" fbc:name="MASE_RS02770" fbc:label="G_MASE_RS02770"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18310" fbc:name="MASE_RS18310" fbc:label="G_MASE_RS18310"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05505" fbc:name="MASE_RS05505" fbc:label="G_MASE_RS05505"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14220" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14220" fbc:name="MASE_RS14220" fbc:label="G_MASE_RS14220"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14210" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14210" fbc:name="MASE_RS14210" fbc:label="G_MASE_RS14210"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14215" fbc:name="MASE_RS14215" fbc:label="G_MASE_RS14215"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00500" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00500" fbc:name="MASE_RS00500" fbc:label="G_MASE_RS00500"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06695" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06695" fbc:name="MASE_RS06695" fbc:label="G_MASE_RS06695"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01930" fbc:name="MASE_RS01930" fbc:label="G_MASE_RS01930"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06925" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06925" fbc:name="MASE_RS06925" fbc:label="G_MASE_RS06925"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11185" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11185" fbc:name="MASE_RS11185" fbc:label="G_MASE_RS11185"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15135" fbc:name="MASE_RS15135" fbc:label="G_MASE_RS15135"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14025" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14025" fbc:name="MASE_RS14025" fbc:label="G_MASE_RS14025"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11255" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11255" fbc:name="MASE_RS11255" fbc:label="G_MASE_RS11255"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12060" fbc:name="MASE_RS12060" fbc:label="G_MASE_RS12060"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19365" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19365" fbc:name="MASE_RS19365" fbc:label="G_MASE_RS19365"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11145" fbc:name="MASE_RS11145" fbc:label="G_MASE_RS11145"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12900" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12900" fbc:name="MASE_RS12900" fbc:label="G_MASE_RS12900"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06990" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06990" fbc:name="MASE_RS06990" fbc:label="G_MASE_RS06990"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17990" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17990" fbc:name="MASE_RS17990" fbc:label="G_MASE_RS17990"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13110" fbc:name="MASE_RS13110" fbc:label="G_MASE_RS13110"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09645" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09645" fbc:name="MASE_RS09645" fbc:label="G_MASE_RS09645"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11260" fbc:name="MASE_RS11260" fbc:label="G_MASE_RS11260"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00495" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00495" fbc:name="MASE_RS00495" fbc:label="G_MASE_RS00495"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10455" fbc:name="MASE_RS10455" fbc:label="G_MASE_RS10455"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11845" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11845" fbc:name="MASE_RS11845" fbc:label="G_MASE_RS11845"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05890" fbc:name="MASE_RS05890" fbc:label="G_MASE_RS05890"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14160" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14160" fbc:name="MASE_RS14160" fbc:label="G_MASE_RS14160"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12140" fbc:name="MASE_RS12140" fbc:label="G_MASE_RS12140"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03365" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03365" fbc:name="MASE_RS03365" fbc:label="G_MASE_RS03365"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06215" fbc:name="MASE_RS06215" fbc:label="G_MASE_RS06215"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01700" fbc:name="MASE_RS01700" fbc:label="G_MASE_RS01700"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07580" fbc:name="MASE_RS07580" fbc:label="G_MASE_RS07580"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16200" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16200" fbc:name="MASE_RS16200" fbc:label="G_MASE_RS16200"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07490" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07490" fbc:name="MASE_RS07490" fbc:label="G_MASE_RS07490"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12410" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12410" fbc:name="MASE_RS12410" fbc:label="G_MASE_RS12410"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02225" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02225" fbc:name="MASE_RS02225" fbc:label="G_MASE_RS02225"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01795" fbc:name="MASE_RS01795" fbc:label="G_MASE_RS01795"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09560" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09560" fbc:name="MASE_RS09560" fbc:label="G_MASE_RS09560"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12075" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12075" fbc:name="MASE_RS12075" fbc:label="G_MASE_RS12075"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07335" fbc:name="MASE_RS07335" fbc:label="G_MASE_RS07335"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07035" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07035" fbc:name="MASE_RS07035" fbc:label="G_MASE_RS07035"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16540" fbc:name="MASE_RS16540" fbc:label="G_MASE_RS16540"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13040" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13040" fbc:name="MASE_RS13040" fbc:label="G_MASE_RS13040"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16950" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16950" fbc:name="MASE_RS16950" fbc:label="G_MASE_RS16950"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06835" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06835" fbc:name="MASE_RS06835" fbc:label="G_MASE_RS06835"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02430" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02430" fbc:name="MASE_RS02430" fbc:label="G_MASE_RS02430"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06555" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06555" fbc:name="MASE_RS06555" fbc:label="G_MASE_RS06555"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08305" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08305" fbc:name="MASE_RS08305" fbc:label="G_MASE_RS08305"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01350" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01350" fbc:name="MASE_RS01350" fbc:label="G_MASE_RS01350"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04425" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04425" fbc:name="MASE_RS04425" fbc:label="G_MASE_RS04425"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14040" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14040" fbc:name="MASE_RS14040" fbc:label="G_MASE_RS14040"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03535" fbc:name="MASE_RS03535" fbc:label="G_MASE_RS03535"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19605" fbc:name="MASE_RS19605" fbc:label="G_MASE_RS19605"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17645" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17645" fbc:name="MASE_RS17645" fbc:label="G_MASE_RS17645"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18175" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18175" fbc:name="MASE_RS18175" fbc:label="G_MASE_RS18175"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09225" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09225" fbc:name="MASE_RS09225" fbc:label="G_MASE_RS09225"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00805" fbc:name="MASE_RS00805" fbc:label="G_MASE_RS00805"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03150" fbc:name="MASE_RS03150" fbc:label="G_MASE_RS03150"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02125" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02125" fbc:name="MASE_RS02125" fbc:label="G_MASE_RS02125"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15505" fbc:name="MASE_RS15505" fbc:label="G_MASE_RS15505"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06545" fbc:name="MASE_RS06545" fbc:label="G_MASE_RS06545"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06465" fbc:name="MASE_RS06465" fbc:label="G_MASE_RS06465"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06470" fbc:name="MASE_RS06470" fbc:label="G_MASE_RS06470"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04280" fbc:name="MASE_RS04280" fbc:label="G_MASE_RS04280"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01885" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01885" fbc:name="MASE_RS01885" fbc:label="G_MASE_RS01885"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13530" fbc:name="MASE_RS13530" fbc:label="G_MASE_RS13530"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07915" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07915" fbc:name="MASE_RS07915" fbc:label="G_MASE_RS07915"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06575" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06575" fbc:name="MASE_RS06575" fbc:label="G_MASE_RS06575"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12065" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12065" fbc:name="MASE_RS12065" fbc:label="G_MASE_RS12065"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15330" fbc:name="MASE_RS15330" fbc:label="G_MASE_RS15330"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18860" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18860" fbc:name="MASE_RS18860" fbc:label="G_MASE_RS18860"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02145" fbc:name="MASE_RS02145" fbc:label="G_MASE_RS02145"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01570" fbc:name="MASE_RS01570" fbc:label="G_MASE_RS01570"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10450" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10450" fbc:name="MASE_RS10450" fbc:label="G_MASE_RS10450"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07245" fbc:name="MASE_RS07245" fbc:label="G_MASE_RS07245"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08485" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08485" fbc:name="MASE_RS08485" fbc:label="G_MASE_RS08485"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01565" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01565" fbc:name="MASE_RS01565" fbc:label="G_MASE_RS01565"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12760" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12760" fbc:name="MASE_RS12760" fbc:label="G_MASE_RS12760"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13825" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13825" fbc:name="MASE_RS13825" fbc:label="G_MASE_RS13825"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02155" fbc:name="MASE_RS02155" fbc:label="G_MASE_RS02155"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07485" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07485" fbc:name="MASE_RS07485" fbc:label="G_MASE_RS07485"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12045" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12045" fbc:name="MASE_RS12045" fbc:label="G_MASE_RS12045"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00680" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00680" fbc:name="MASE_RS00680" fbc:label="G_MASE_RS00680"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09545" fbc:name="MASE_RS09545" fbc:label="G_MASE_RS09545"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15560" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15560" fbc:name="MASE_RS15560" fbc:label="G_MASE_RS15560"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17475" fbc:name="MASE_RS17475" fbc:label="G_MASE_RS17475"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16745" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16745" fbc:name="MASE_RS16745" fbc:label="G_MASE_RS16745"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07030" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07030" fbc:name="MASE_RS07030" fbc:label="G_MASE_RS07030"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13525" fbc:name="MASE_RS13525" fbc:label="G_MASE_RS13525"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13535" fbc:name="MASE_RS13535" fbc:label="G_MASE_RS13535"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14890" fbc:name="MASE_RS14890" fbc:label="G_MASE_RS14890"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10485" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10485" fbc:name="MASE_RS10485" fbc:label="G_MASE_RS10485"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14725" fbc:name="MASE_RS14725" fbc:label="G_MASE_RS14725"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09570" fbc:name="MASE_RS09570" fbc:label="G_MASE_RS09570"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07235" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07235" fbc:name="MASE_RS07235" fbc:label="G_MASE_RS07235"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00090" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00090" fbc:name="MASE_RS00090" fbc:label="G_MASE_RS00090"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00095" fbc:name="MASE_RS00095" fbc:label="G_MASE_RS00095"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17745" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17745" fbc:name="MASE_RS17745" fbc:label="G_MASE_RS17745"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10135" fbc:name="MASE_RS10135" fbc:label="G_MASE_RS10135"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07610" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07610" fbc:name="MASE_RS07610" fbc:label="G_MASE_RS07610"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12720" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12720" fbc:name="MASE_RS12720" fbc:label="G_MASE_RS12720"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03355" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03355" fbc:name="MASE_RS03355" fbc:label="G_MASE_RS03355"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10200" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10200" fbc:name="MASE_RS10200" fbc:label="G_MASE_RS10200"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09245" fbc:name="MASE_RS09245" fbc:label="G_MASE_RS09245"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15245" fbc:name="MASE_RS15245" fbc:label="G_MASE_RS15245"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02440" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02440" fbc:name="MASE_RS02440" fbc:label="G_MASE_RS02440"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04415" fbc:name="MASE_RS04415" fbc:label="G_MASE_RS04415"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13510" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13510" fbc:name="MASE_RS13510" fbc:label="G_MASE_RS13510"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13020" fbc:name="MASE_RS13020" fbc:label="G_MASE_RS13020"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17605" fbc:name="MASE_RS17605" fbc:label="G_MASE_RS17605"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08060" fbc:name="MASE_RS08060" fbc:label="G_MASE_RS08060"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12330" fbc:name="MASE_RS12330" fbc:label="G_MASE_RS12330"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03630" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03630" fbc:name="MASE_RS03630" fbc:label="G_MASE_RS03630"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03010" fbc:name="MASE_RS03010" fbc:label="G_MASE_RS03010"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03635" fbc:name="MASE_RS03635" fbc:label="G_MASE_RS03635"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09660" fbc:name="MASE_RS09660" fbc:label="G_MASE_RS09660"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05060" fbc:name="MASE_RS05060" fbc:label="G_MASE_RS05060"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02815" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02815" fbc:name="MASE_RS02815" fbc:label="G_MASE_RS02815"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12990" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12990" fbc:name="MASE_RS12990" fbc:label="G_MASE_RS12990"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17360" fbc:name="MASE_RS17360" fbc:label="G_MASE_RS17360"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17960" fbc:name="MASE_RS17960" fbc:label="G_MASE_RS17960"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16515" fbc:name="MASE_RS16515" fbc:label="G_MASE_RS16515"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06280" fbc:name="MASE_RS06280" fbc:label="G_MASE_RS06280"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08380" fbc:name="MASE_RS08380" fbc:label="G_MASE_RS08380"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04260" fbc:name="MASE_RS04260" fbc:label="G_MASE_RS04260"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06395" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06395" fbc:name="MASE_RS06395" fbc:label="G_MASE_RS06395"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00570" fbc:name="MASE_RS00570" fbc:label="G_MASE_RS00570"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17565" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17565" fbc:name="MASE_RS17565" fbc:label="G_MASE_RS17565"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09115" fbc:name="MASE_RS09115" fbc:label="G_MASE_RS09115"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06110" fbc:name="MASE_RS06110" fbc:label="G_MASE_RS06110"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11655" fbc:name="MASE_RS11655" fbc:label="G_MASE_RS11655"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17205" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17205" fbc:name="MASE_RS17205" fbc:label="G_MASE_RS17205"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16215" fbc:name="MASE_RS16215" fbc:label="G_MASE_RS16215"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14720" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14720" fbc:name="MASE_RS14720" fbc:label="G_MASE_RS14720"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12615" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12615" fbc:name="MASE_RS12615" fbc:label="G_MASE_RS12615"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08705" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08705" fbc:name="MASE_RS08705" fbc:label="G_MASE_RS08705"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03555" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03555" fbc:name="MASE_RS03555" fbc:label="G_MASE_RS03555"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07990" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07990" fbc:name="MASE_RS07990" fbc:label="G_MASE_RS07990"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14995" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14995" fbc:name="MASE_RS14995" fbc:label="G_MASE_RS14995"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02020" fbc:name="MASE_RS02020" fbc:label="G_MASE_RS02020"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04470" fbc:name="MASE_RS04470" fbc:label="G_MASE_RS04470"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11640" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11640" fbc:name="MASE_RS11640" fbc:label="G_MASE_RS11640"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12745" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12745" fbc:name="MASE_RS12745" fbc:label="G_MASE_RS12745"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15790" fbc:name="MASE_RS15790" fbc:label="G_MASE_RS15790"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00290" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00290" fbc:name="MASE_RS00290" fbc:label="G_MASE_RS00290"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14860" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14860" fbc:name="MASE_RS14860" fbc:label="G_MASE_RS14860"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12095" fbc:name="MASE_RS12095" fbc:label="G_MASE_RS12095"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04115" fbc:name="MASE_RS04115" fbc:label="G_MASE_RS04115"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11300" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11300" fbc:name="MASE_RS11300" fbc:label="G_MASE_RS11300"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11155" fbc:name="MASE_RS11155" fbc:label="G_MASE_RS11155"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02780" fbc:name="MASE_RS02780" fbc:label="G_MASE_RS02780"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02595" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02595" fbc:name="MASE_RS02595" fbc:label="G_MASE_RS02595"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16555" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16555" fbc:name="MASE_RS16555" fbc:label="G_MASE_RS16555"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01370" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01370" fbc:name="MASE_RS01370" fbc:label="G_MASE_RS01370"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05105" fbc:name="MASE_RS05105" fbc:label="G_MASE_RS05105"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00515" fbc:name="MASE_RS00515" fbc:label="G_MASE_RS00515"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03240" fbc:name="MASE_RS03240" fbc:label="G_MASE_RS03240"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17115" fbc:name="MASE_RS17115" fbc:label="G_MASE_RS17115"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18525" fbc:name="MASE_RS18525" fbc:label="G_MASE_RS18525"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12385" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12385" fbc:name="MASE_RS12385" fbc:label="G_MASE_RS12385"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19150" fbc:name="MASE_RS19150" fbc:label="G_MASE_RS19150"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08445" fbc:name="MASE_RS08445" fbc:label="G_MASE_RS08445"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10615" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10615" fbc:name="MASE_RS10615" fbc:label="G_MASE_RS10615"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05930" fbc:name="MASE_RS05930" fbc:label="G_MASE_RS05930"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04295" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04295" fbc:name="MASE_RS04295" fbc:label="G_MASE_RS04295"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18335" fbc:name="MASE_RS18335" fbc:label="G_MASE_RS18335"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01585" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01585" fbc:name="MASE_RS01585" fbc:label="G_MASE_RS01585"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13920" fbc:name="MASE_RS13920" fbc:label="G_MASE_RS13920"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00155" fbc:name="MASE_RS00155" fbc:label="G_MASE_RS00155"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14870" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14870" fbc:name="MASE_RS14870" fbc:label="G_MASE_RS14870"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16250" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16250" fbc:name="MASE_RS16250" fbc:label="G_MASE_RS16250"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11570" fbc:name="MASE_RS11570" fbc:label="G_MASE_RS11570"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16210" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16210" fbc:name="MASE_RS16210" fbc:label="G_MASE_RS16210"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13900" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13900" fbc:name="MASE_RS13900" fbc:label="G_MASE_RS13900"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11620" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11620" fbc:name="MASE_RS11620" fbc:label="G_MASE_RS11620"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02400" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02400" fbc:name="MASE_RS02400" fbc:label="G_MASE_RS02400"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03220" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03220" fbc:name="MASE_RS03220" fbc:label="G_MASE_RS03220"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02475" fbc:name="MASE_RS02475" fbc:label="G_MASE_RS02475"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12085" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12085" fbc:name="MASE_RS12085" fbc:label="G_MASE_RS12085"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19455" fbc:name="MASE_RS19455" fbc:label="G_MASE_RS19455"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13810" fbc:name="MASE_RS13810" fbc:label="G_MASE_RS13810"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11605" fbc:name="MASE_RS11605" fbc:label="G_MASE_RS11605"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09120" fbc:name="MASE_RS09120" fbc:label="G_MASE_RS09120"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09125" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09125" fbc:name="MASE_RS09125" fbc:label="G_MASE_RS09125"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09640" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09640" fbc:name="MASE_RS09640" fbc:label="G_MASE_RS09640"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11695" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11695" fbc:name="MASE_RS11695" fbc:label="G_MASE_RS11695"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00325" fbc:name="MASE_RS00325" fbc:label="G_MASE_RS00325"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03795" fbc:name="MASE_RS03795" fbc:label="G_MASE_RS03795"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19420" fbc:name="MASE_RS19420" fbc:label="G_MASE_RS19420"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18985" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18985" fbc:name="MASE_RS18985" fbc:label="G_MASE_RS18985"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05130" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05130" fbc:name="MASE_RS05130" fbc:label="G_MASE_RS05130"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02170" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02170" fbc:name="MASE_RS02170" fbc:label="G_MASE_RS02170"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01120" fbc:name="MASE_RS01120" fbc:label="G_MASE_RS01120"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13290" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13290" fbc:name="MASE_RS13290" fbc:label="G_MASE_RS13290"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01330" fbc:name="MASE_RS01330" fbc:label="G_MASE_RS01330"/>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08695" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08695" fbc:name="MASE_RS08695" fbc:label="G_MASE_RS08695">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08695">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949366.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17325" fbc:name="MASE_RS17325" fbc:label="G_MASE_RS17325">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17325">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951000.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02955" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02955" fbc:name="MASE_RS02955" fbc:label="G_MASE_RS02955">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02955">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948272.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00670" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00670" fbc:name="MASE_RS00670" fbc:label="G_MASE_RS00670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947834.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14345" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14345" fbc:name="MASE_RS14345" fbc:label="G_MASE_RS14345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950459.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09535" fbc:name="MASE_RS09535" fbc:label="G_MASE_RS09535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949531.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09540" fbc:name="MASE_RS09540" fbc:label="G_MASE_RS09540">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09540">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949532.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07515" fbc:name="MASE_RS07515" fbc:label="G_MASE_RS07515">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07515">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949139.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12890" fbc:name="MASE_RS12890" fbc:label="G_MASE_RS12890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950181.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07445" fbc:name="MASE_RS07445" fbc:label="G_MASE_RS07445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949126.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00730" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00730" fbc:name="MASE_RS00730" fbc:label="G_MASE_RS00730">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00730">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947845.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10115" fbc:name="MASE_RS10115" fbc:label="G_MASE_RS10115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949643.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11265" fbc:name="MASE_RS11265" fbc:label="G_MASE_RS11265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949871.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14145" fbc:name="MASE_RS14145" fbc:label="G_MASE_RS14145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950429.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11785" fbc:name="MASE_RS11785" fbc:label="G_MASE_RS11785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949972.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11780" fbc:name="MASE_RS11780" fbc:label="G_MASE_RS11780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949971.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10945" fbc:name="MASE_RS10945" fbc:label="G_MASE_RS10945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949806.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11950" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11950" fbc:name="MASE_RS11950" fbc:label="G_MASE_RS11950">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11950">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950005.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03070" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03070" fbc:name="MASE_RS03070" fbc:label="G_MASE_RS03070">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03070">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948293.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15710" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15710" fbc:name="MASE_RS15710" fbc:label="G_MASE_RS15710">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15710">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949497.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09360" fbc:name="MASE_RS09360" fbc:label="G_MASE_RS09360">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09360">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949497.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05470" fbc:name="MASE_RS05470" fbc:label="G_MASE_RS05470">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05470">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948753.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12830" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12830" fbc:name="MASE_RS12830" fbc:label="G_MASE_RS12830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519000.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18890" fbc:name="MASE_RS18890" fbc:label="G_MASE_RS18890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951302.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06935" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06935" fbc:name="MASE_RS06935" fbc:label="G_MASE_RS06935">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06935">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949030.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12110" fbc:name="MASE_RS12110" fbc:label="G_MASE_RS12110">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12110">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950037.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13980" fbc:name="MASE_RS13980" fbc:label="G_MASE_RS13980">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13980">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950396.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16655" fbc:name="MASE_RS16655" fbc:label="G_MASE_RS16655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950878.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13335" fbc:name="MASE_RS13335" fbc:label="G_MASE_RS13335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950270.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00165" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00165" fbc:name="MASE_RS00165" fbc:label="G_MASE_RS00165">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00165">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947740.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16550" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16550" fbc:name="MASE_RS16550" fbc:label="G_MASE_RS16550">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16550">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950859.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08000" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08000" fbc:name="MASE_RS08000" fbc:label="G_MASE_RS08000">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08000">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949230.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08675" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08675" fbc:name="MASE_RS08675" fbc:label="G_MASE_RS08675">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08675">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949362.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05770" fbc:name="MASE_RS05770" fbc:label="G_MASE_RS05770">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05770">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948810.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02310" fbc:name="MASE_RS02310" fbc:label="G_MASE_RS02310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948146.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07910" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07910" fbc:name="MASE_RS07910" fbc:label="G_MASE_RS07910">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07910">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949213.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02330" fbc:name="MASE_RS02330" fbc:label="G_MASE_RS02330">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02330">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948150.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03200" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03200" fbc:name="MASE_RS03200" fbc:label="G_MASE_RS03200">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03200">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948317.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08510" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08510" fbc:name="MASE_RS08510" fbc:label="G_MASE_RS08510">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08510">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949329.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09260" fbc:name="MASE_RS09260" fbc:label="G_MASE_RS09260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949477.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12240" fbc:name="MASE_RS12240" fbc:label="G_MASE_RS12240">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12240">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950059.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01650" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01650" fbc:name="MASE_RS01650" fbc:label="G_MASE_RS01650">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01650">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948021.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13390" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13390" fbc:name="MASE_RS13390" fbc:label="G_MASE_RS13390">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13390">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950281.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12370" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12370" fbc:name="MASE_RS12370" fbc:label="G_MASE_RS12370">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12370">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950085.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04390" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04390" fbc:name="MASE_RS04390" fbc:label="G_MASE_RS04390">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04390">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948551.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15070" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15070" fbc:name="MASE_RS15070" fbc:label="G_MASE_RS15070">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15070">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950602.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11360" fbc:name="MASE_RS11360" fbc:label="G_MASE_RS11360">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11360">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949890.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09610" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09610" fbc:name="MASE_RS09610" fbc:label="G_MASE_RS09610">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09610">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949546.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07665" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07665" fbc:name="MASE_RS07665" fbc:label="G_MASE_RS07665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949169.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17300" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17300" fbc:name="MASE_RS17300" fbc:label="G_MASE_RS17300">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17300">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950995.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05690" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05690" fbc:name="MASE_RS05690" fbc:label="G_MASE_RS05690">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05690">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948795.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05705" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05705" fbc:name="MASE_RS05705" fbc:label="G_MASE_RS05705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948797.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08490" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08490" fbc:name="MASE_RS08490" fbc:label="G_MASE_RS08490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949325.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16245" fbc:name="MASE_RS16245" fbc:label="G_MASE_RS16245">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16245">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950808.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00240" fbc:name="MASE_RS00240" fbc:label="G_MASE_RS00240">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00240">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947751.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16535" fbc:name="MASE_RS16535" fbc:label="G_MASE_RS16535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950856.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19535" fbc:name="MASE_RS19535" fbc:label="G_MASE_RS19535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951417.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08775" fbc:name="MASE_RS08775" fbc:label="G_MASE_RS08775">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08775">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949381.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11635" fbc:name="MASE_RS11635" fbc:label="G_MASE_RS11635">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11635">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949944.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19265" fbc:name="MASE_RS19265" fbc:label="G_MASE_RS19265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951376.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06330" fbc:name="MASE_RS06330" fbc:label="G_MASE_RS06330">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06330">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948922.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04350" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04350" fbc:name="MASE_RS04350" fbc:label="G_MASE_RS04350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948543.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11920" fbc:name="MASE_RS11920" fbc:label="G_MASE_RS11920">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11920">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949999.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11725" fbc:name="MASE_RS11725" fbc:label="G_MASE_RS11725">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11725">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949960.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14820" fbc:name="MASE_RS14820" fbc:label="G_MASE_RS14820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950553.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02790" fbc:name="MASE_RS02790" fbc:label="G_MASE_RS02790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948240.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13850" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13850" fbc:name="MASE_RS13850" fbc:label="G_MASE_RS13850">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13850">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950371.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03610" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03610" fbc:name="MASE_RS03610" fbc:label="G_MASE_RS03610">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03610">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948397.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02025" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02025" fbc:name="MASE_RS02025" fbc:label="G_MASE_RS02025">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02025">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948093.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19155" fbc:name="MASE_RS19155" fbc:label="G_MASE_RS19155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951355.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09415" fbc:name="MASE_RS09415" fbc:label="G_MASE_RS09415">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09415">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949508.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14230" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14230" fbc:name="MASE_RS14230" fbc:label="G_MASE_RS14230">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14230">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_187289714.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05835" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05835" fbc:name="MASE_RS05835" fbc:label="G_MASE_RS05835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948826.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14280" fbc:name="MASE_RS14280" fbc:label="G_MASE_RS14280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_187289714.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01855" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01855" fbc:name="MASE_RS01855" fbc:label="G_MASE_RS01855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948061.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15530" fbc:name="MASE_RS15530" fbc:label="G_MASE_RS15530">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15530">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950689.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12070" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12070" fbc:name="MASE_RS12070" fbc:label="G_MASE_RS12070">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12070">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950029.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17840" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17840" fbc:name="MASE_RS17840" fbc:label="G_MASE_RS17840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951100.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02950" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02950" fbc:name="MASE_RS02950" fbc:label="G_MASE_RS02950">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02950">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948271.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12595" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12595" fbc:name="MASE_RS12595" fbc:label="G_MASE_RS12595">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12595">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950128.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12500" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12500" fbc:name="MASE_RS12500" fbc:label="G_MASE_RS12500">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12500">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_051129059.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06010" fbc:name="MASE_RS06010" fbc:label="G_MASE_RS06010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948861.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12180" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12180" fbc:name="MASE_RS12180" fbc:label="G_MASE_RS12180">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12180">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950051.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09935" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09935" fbc:name="MASE_RS09935" fbc:label="G_MASE_RS09935">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09935">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949608.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09095" fbc:name="MASE_RS09095" fbc:label="G_MASE_RS09095">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09095">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949446.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09090" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09090" fbc:name="MASE_RS09090" fbc:label="G_MASE_RS09090">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09090">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949445.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09100" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09100" fbc:name="MASE_RS09100" fbc:label="G_MASE_RS09100">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09100">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949447.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09105" fbc:name="MASE_RS09105" fbc:label="G_MASE_RS09105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518362.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19335" fbc:name="MASE_RS19335" fbc:label="G_MASE_RS19335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951390.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15020" fbc:name="MASE_RS15020" fbc:label="G_MASE_RS15020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950593.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04420" fbc:name="MASE_RS04420" fbc:label="G_MASE_RS04420">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04420">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948557.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19345" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19345" fbc:name="MASE_RS19345" fbc:label="G_MASE_RS19345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951392.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09675" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09675" fbc:name="MASE_RS09675" fbc:label="G_MASE_RS09675">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09675">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949559.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04445" fbc:name="MASE_RS04445" fbc:label="G_MASE_RS04445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948562.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12390" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12390" fbc:name="MASE_RS12390" fbc:label="G_MASE_RS12390">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12390">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950089.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00920" fbc:name="MASE_RS00920" fbc:label="G_MASE_RS00920">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00920">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947884.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00945" fbc:name="MASE_RS00945" fbc:label="G_MASE_RS00945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947889.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17660" fbc:name="MASE_RS17660" fbc:label="G_MASE_RS17660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951064.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01105" fbc:name="MASE_RS01105" fbc:label="G_MASE_RS01105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947921.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06075" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06075" fbc:name="MASE_RS06075" fbc:label="G_MASE_RS06075">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06075">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948872.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14505" fbc:name="MASE_RS14505" fbc:label="G_MASE_RS14505">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14505">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950490.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18325" fbc:name="MASE_RS18325" fbc:label="G_MASE_RS18325">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18325">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951196.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14795" fbc:name="MASE_RS14795" fbc:label="G_MASE_RS14795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950548.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11190" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11190" fbc:name="MASE_RS11190" fbc:label="G_MASE_RS11190">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11190">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949856.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19340" fbc:name="MASE_RS19340" fbc:label="G_MASE_RS19340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951391.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09505" fbc:name="MASE_RS09505" fbc:label="G_MASE_RS09505">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09505">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949525.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16000" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16000" fbc:name="MASE_RS16000" fbc:label="G_MASE_RS16000">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16000">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950759.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16675" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16675" fbc:name="MASE_RS16675" fbc:label="G_MASE_RS16675">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16675">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950882.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03360" fbc:name="MASE_RS03360" fbc:label="G_MASE_RS03360">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03360">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948347.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03135" fbc:name="MASE_RS03135" fbc:label="G_MASE_RS03135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948306.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00810" fbc:name="MASE_RS00810" fbc:label="G_MASE_RS00810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947861.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03545" fbc:name="MASE_RS03545" fbc:label="G_MASE_RS03545">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03545">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948384.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08605" fbc:name="MASE_RS08605" fbc:label="G_MASE_RS08605">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08605">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949348.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08895" fbc:name="MASE_RS08895" fbc:label="G_MASE_RS08895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949405.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03645" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03645" fbc:name="MASE_RS03645" fbc:label="G_MASE_RS03645">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03645">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948404.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10085" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10085" fbc:name="MASE_RS10085" fbc:label="G_MASE_RS10085">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10085">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949637.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00475" fbc:name="MASE_RS00475" fbc:label="G_MASE_RS00475">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00475">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947796.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17215" fbc:name="MASE_RS17215" fbc:label="G_MASE_RS17215">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17215">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950980.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10865" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10865" fbc:name="MASE_RS10865" fbc:label="G_MASE_RS10865">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10865">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949790.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09780" fbc:name="MASE_RS09780" fbc:label="G_MASE_RS09780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949581.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03560" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03560" fbc:name="MASE_RS03560" fbc:label="G_MASE_RS03560">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03560">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948387.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07155" fbc:name="MASE_RS07155" fbc:label="G_MASE_RS07155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949072.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07150" fbc:name="MASE_RS07150" fbc:label="G_MASE_RS07150">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07150">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949071.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04010" fbc:name="MASE_RS04010" fbc:label="G_MASE_RS04010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948475.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06450" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06450" fbc:name="MASE_RS06450" fbc:label="G_MASE_RS06450">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06450">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948941.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06445" fbc:name="MASE_RS06445" fbc:label="G_MASE_RS06445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948940.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06965" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06965" fbc:name="MASE_RS06965" fbc:label="G_MASE_RS06965">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06965">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949036.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09010" fbc:name="MASE_RS09010" fbc:label="G_MASE_RS09010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949429.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00800" fbc:name="MASE_RS00800" fbc:label="G_MASE_RS00800">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00800">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947859.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16660" fbc:name="MASE_RS16660" fbc:label="G_MASE_RS16660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950879.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06890" fbc:name="MASE_RS06890" fbc:label="G_MASE_RS06890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949022.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03120" fbc:name="MASE_RS03120" fbc:label="G_MASE_RS03120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948303.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14490" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14490" fbc:name="MASE_RS14490" fbc:label="G_MASE_RS14490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950487.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05710" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05710" fbc:name="MASE_RS05710" fbc:label="G_MASE_RS05710">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05710">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948798.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08770" fbc:name="MASE_RS08770" fbc:label="G_MASE_RS08770">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08770">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949380.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07640" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07640" fbc:name="MASE_RS07640" fbc:label="G_MASE_RS07640">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07640">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949164.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12455" fbc:name="MASE_RS12455" fbc:label="G_MASE_RS12455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950101.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07955" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07955" fbc:name="MASE_RS07955" fbc:label="G_MASE_RS07955">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07955">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949221.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02630" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02630" fbc:name="MASE_RS02630" fbc:label="G_MASE_RS02630">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02630">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948208.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07905" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07905" fbc:name="MASE_RS07905" fbc:label="G_MASE_RS07905">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07905">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949212.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11685" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11685" fbc:name="MASE_RS11685" fbc:label="G_MASE_RS11685">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11685">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949953.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07925" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07925" fbc:name="MASE_RS07925" fbc:label="G_MASE_RS07925">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07925">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949215.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03810" fbc:name="MASE_RS03810" fbc:label="G_MASE_RS03810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948437.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19435" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19435" fbc:name="MASE_RS19435" fbc:label="G_MASE_RS19435">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19435">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948437.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07630" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07630" fbc:name="MASE_RS07630" fbc:label="G_MASE_RS07630">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07630">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949162.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05765" fbc:name="MASE_RS05765" fbc:label="G_MASE_RS05765">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05765">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948809.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02305" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02305" fbc:name="MASE_RS02305" fbc:label="G_MASE_RS02305">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02305">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948145.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08005" fbc:name="MASE_RS08005" fbc:label="G_MASE_RS08005">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949231.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11140" fbc:name="MASE_RS11140" fbc:label="G_MASE_RS11140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949846.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10350" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10350" fbc:name="MASE_RS10350" fbc:label="G_MASE_RS10350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949690.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13140" fbc:name="MASE_RS13140" fbc:label="G_MASE_RS13140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950232.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05665" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05665" fbc:name="MASE_RS05665" fbc:label="G_MASE_RS05665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948790.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13185" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13185" fbc:name="MASE_RS13185" fbc:label="G_MASE_RS13185">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13185">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950241.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09255" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09255" fbc:name="MASE_RS09255" fbc:label="G_MASE_RS09255">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09255">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949476.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09110" fbc:name="MASE_RS09110" fbc:label="G_MASE_RS09110">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09110">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949448.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09725" fbc:name="MASE_RS09725" fbc:label="G_MASE_RS09725">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09725">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232362839.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07920" fbc:name="MASE_RS07920" fbc:label="G_MASE_RS07920">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07920">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518211.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01920" fbc:name="MASE_RS01920" fbc:label="G_MASE_RS01920">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01920">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948074.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04065" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04065" fbc:name="MASE_RS04065" fbc:label="G_MASE_RS04065">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04065">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948485.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18760" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18760" fbc:name="MASE_RS18760" fbc:label="G_MASE_RS18760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951277.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18755" fbc:name="MASE_RS18755" fbc:label="G_MASE_RS18755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951276.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16455" fbc:name="MASE_RS16455" fbc:label="G_MASE_RS16455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950846.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01705" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01705" fbc:name="MASE_RS01705" fbc:label="G_MASE_RS01705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948032.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05900" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05900" fbc:name="MASE_RS05900" fbc:label="G_MASE_RS05900">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05900">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948839.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10120" fbc:name="MASE_RS10120" fbc:label="G_MASE_RS10120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949644.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16780" fbc:name="MASE_RS16780" fbc:label="G_MASE_RS16780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950903.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07310" fbc:name="MASE_RS07310" fbc:label="G_MASE_RS07310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949100.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05700" fbc:name="MASE_RS05700" fbc:label="G_MASE_RS05700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948796.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13445" fbc:name="MASE_RS13445" fbc:label="G_MASE_RS13445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950291.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13270" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13270" fbc:name="MASE_RS13270" fbc:label="G_MASE_RS13270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950257.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10275" fbc:name="MASE_RS10275" fbc:label="G_MASE_RS10275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949675.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00425" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00425" fbc:name="MASE_RS00425" fbc:label="G_MASE_RS00425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947786.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10530" fbc:name="MASE_RS10530" fbc:label="G_MASE_RS10530">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10530">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949727.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08010" fbc:name="MASE_RS08010" fbc:label="G_MASE_RS08010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949232.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10725" fbc:name="MASE_RS10725" fbc:label="G_MASE_RS10725">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10725">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949762.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00755" fbc:name="MASE_RS00755" fbc:label="G_MASE_RS00755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947850.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00525" fbc:name="MASE_RS00525" fbc:label="G_MASE_RS00525">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00525">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947806.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02765" fbc:name="MASE_RS02765" fbc:label="G_MASE_RS02765">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02765">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948235.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02770" fbc:name="MASE_RS02770" fbc:label="G_MASE_RS02770">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02770">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948236.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18310" fbc:name="MASE_RS18310" fbc:label="G_MASE_RS18310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951193.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05505" fbc:name="MASE_RS05505" fbc:label="G_MASE_RS05505">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05505">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948760.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14220" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14220" fbc:name="MASE_RS14220" fbc:label="G_MASE_RS14220">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14220">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950443.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14210" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14210" fbc:name="MASE_RS14210" fbc:label="G_MASE_RS14210">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14210">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950441.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14215" fbc:name="MASE_RS14215" fbc:label="G_MASE_RS14215">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14215">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950442.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00500" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00500" fbc:name="MASE_RS00500" fbc:label="G_MASE_RS00500">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00500">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947801.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06695" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06695" fbc:name="MASE_RS06695" fbc:label="G_MASE_RS06695">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06695">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948987.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01930" fbc:name="MASE_RS01930" fbc:label="G_MASE_RS01930">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01930">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948076.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06925" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06925" fbc:name="MASE_RS06925" fbc:label="G_MASE_RS06925">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06925">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949029.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11185" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11185" fbc:name="MASE_RS11185" fbc:label="G_MASE_RS11185">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11185">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949855.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15135" fbc:name="MASE_RS15135" fbc:label="G_MASE_RS15135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950614.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14025" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14025" fbc:name="MASE_RS14025" fbc:label="G_MASE_RS14025">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14025">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950405.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11255" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11255" fbc:name="MASE_RS11255" fbc:label="G_MASE_RS11255">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11255">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949869.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12060" fbc:name="MASE_RS12060" fbc:label="G_MASE_RS12060">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12060">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950027.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19365" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19365" fbc:name="MASE_RS19365" fbc:label="G_MASE_RS19365">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19365">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951396.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11145" fbc:name="MASE_RS11145" fbc:label="G_MASE_RS11145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949847.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12900" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12900" fbc:name="MASE_RS12900" fbc:label="G_MASE_RS12900">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12900">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950183.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06990" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06990" fbc:name="MASE_RS06990" fbc:label="G_MASE_RS06990">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06990">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949041.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17990" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17990" fbc:name="MASE_RS17990" fbc:label="G_MASE_RS17990">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17990">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951128.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13110" fbc:name="MASE_RS13110" fbc:label="G_MASE_RS13110">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13110">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950226.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09645" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09645" fbc:name="MASE_RS09645" fbc:label="G_MASE_RS09645">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09645">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949553.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11260" fbc:name="MASE_RS11260" fbc:label="G_MASE_RS11260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693774.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00495" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00495" fbc:name="MASE_RS00495" fbc:label="G_MASE_RS00495">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00495">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947800.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10455" fbc:name="MASE_RS10455" fbc:label="G_MASE_RS10455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_230598867.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11845" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11845" fbc:name="MASE_RS11845" fbc:label="G_MASE_RS11845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949984.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05890" fbc:name="MASE_RS05890" fbc:label="G_MASE_RS05890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948837.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14160" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14160" fbc:name="MASE_RS14160" fbc:label="G_MASE_RS14160">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14160">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950432.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12140" fbc:name="MASE_RS12140" fbc:label="G_MASE_RS12140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950043.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03365" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03365" fbc:name="MASE_RS03365" fbc:label="G_MASE_RS03365">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03365">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948348.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06215" fbc:name="MASE_RS06215" fbc:label="G_MASE_RS06215">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06215">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948899.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01700" fbc:name="MASE_RS01700" fbc:label="G_MASE_RS01700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948031.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07580" fbc:name="MASE_RS07580" fbc:label="G_MASE_RS07580">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07580">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949152.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16200" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16200" fbc:name="MASE_RS16200" fbc:label="G_MASE_RS16200">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16200">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950799.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07490" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07490" fbc:name="MASE_RS07490" fbc:label="G_MASE_RS07490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949134.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12410" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12410" fbc:name="MASE_RS12410" fbc:label="G_MASE_RS12410">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12410">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950092.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02225" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02225" fbc:name="MASE_RS02225" fbc:label="G_MASE_RS02225">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02225">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948130.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01795" fbc:name="MASE_RS01795" fbc:label="G_MASE_RS01795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948049.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09560" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09560" fbc:name="MASE_RS09560" fbc:label="G_MASE_RS09560">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09560">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949536.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12075" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12075" fbc:name="MASE_RS12075" fbc:label="G_MASE_RS12075">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12075">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950030.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07335" fbc:name="MASE_RS07335" fbc:label="G_MASE_RS07335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693445.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07035" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07035" fbc:name="MASE_RS07035" fbc:label="G_MASE_RS07035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949050.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16540" fbc:name="MASE_RS16540" fbc:label="G_MASE_RS16540">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16540">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950857.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13040" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13040" fbc:name="MASE_RS13040" fbc:label="G_MASE_RS13040">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13040">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950211.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16950" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16950" fbc:name="MASE_RS16950" fbc:label="G_MASE_RS16950">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16950">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950927.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06835" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06835" fbc:name="MASE_RS06835" fbc:label="G_MASE_RS06835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949012.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02430" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02430" fbc:name="MASE_RS02430" fbc:label="G_MASE_RS02430">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02430">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948168.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06555" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06555" fbc:name="MASE_RS06555" fbc:label="G_MASE_RS06555">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06555">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693433.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08305" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08305" fbc:name="MASE_RS08305" fbc:label="G_MASE_RS08305">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08305">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949289.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01350" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01350" fbc:name="MASE_RS01350" fbc:label="G_MASE_RS01350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947968.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04425" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04425" fbc:name="MASE_RS04425" fbc:label="G_MASE_RS04425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948558.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14040" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14040" fbc:name="MASE_RS14040" fbc:label="G_MASE_RS14040">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14040">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950408.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03535" fbc:name="MASE_RS03535" fbc:label="G_MASE_RS03535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948382.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19605" fbc:name="MASE_RS19605" fbc:label="G_MASE_RS19605">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19605">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951431.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17645" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17645" fbc:name="MASE_RS17645" fbc:label="G_MASE_RS17645">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17645">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951061.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18175" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18175" fbc:name="MASE_RS18175" fbc:label="G_MASE_RS18175">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18175">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951166.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09225" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09225" fbc:name="MASE_RS09225" fbc:label="G_MASE_RS09225">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09225">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949470.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00805" fbc:name="MASE_RS00805" fbc:label="G_MASE_RS00805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947860.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03150" fbc:name="MASE_RS03150" fbc:label="G_MASE_RS03150">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03150">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948309.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02125" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02125" fbc:name="MASE_RS02125" fbc:label="G_MASE_RS02125">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02125">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948110.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15505" fbc:name="MASE_RS15505" fbc:label="G_MASE_RS15505">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15505">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950684.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06545" fbc:name="MASE_RS06545" fbc:label="G_MASE_RS06545">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06545">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948959.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06465" fbc:name="MASE_RS06465" fbc:label="G_MASE_RS06465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948944.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06470" fbc:name="MASE_RS06470" fbc:label="G_MASE_RS06470">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06470">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948945.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04280" fbc:name="MASE_RS04280" fbc:label="G_MASE_RS04280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948529.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01885" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01885" fbc:name="MASE_RS01885" fbc:label="G_MASE_RS01885">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01885">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948067.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13530" fbc:name="MASE_RS13530" fbc:label="G_MASE_RS13530">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13530">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950307.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07915" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07915" fbc:name="MASE_RS07915" fbc:label="G_MASE_RS07915">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07915">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949214.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06575" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06575" fbc:name="MASE_RS06575" fbc:label="G_MASE_RS06575">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06575">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948965.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12065" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12065" fbc:name="MASE_RS12065" fbc:label="G_MASE_RS12065">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12065">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950028.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15330" fbc:name="MASE_RS15330" fbc:label="G_MASE_RS15330">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15330">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950650.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18860" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18860" fbc:name="MASE_RS18860" fbc:label="G_MASE_RS18860">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18860">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951296.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02145" fbc:name="MASE_RS02145" fbc:label="G_MASE_RS02145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948114.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01570" fbc:name="MASE_RS01570" fbc:label="G_MASE_RS01570">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01570">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948005.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10450" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10450" fbc:name="MASE_RS10450" fbc:label="G_MASE_RS10450">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10450">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949711.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07245" fbc:name="MASE_RS07245" fbc:label="G_MASE_RS07245">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07245">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949090.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08485" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08485" fbc:name="MASE_RS08485" fbc:label="G_MASE_RS08485">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08485">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949324.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01565" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01565" fbc:name="MASE_RS01565" fbc:label="G_MASE_RS01565">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01565">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948004.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12760" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12760" fbc:name="MASE_RS12760" fbc:label="G_MASE_RS12760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950157.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13825" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13825" fbc:name="MASE_RS13825" fbc:label="G_MASE_RS13825">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13825">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950366.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02155" fbc:name="MASE_RS02155" fbc:label="G_MASE_RS02155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948116.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07485" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07485" fbc:name="MASE_RS07485" fbc:label="G_MASE_RS07485">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07485">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949133.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12045" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12045" fbc:name="MASE_RS12045" fbc:label="G_MASE_RS12045">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12045">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232362759.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00680" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00680" fbc:name="MASE_RS00680" fbc:label="G_MASE_RS00680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947836.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09545" fbc:name="MASE_RS09545" fbc:label="G_MASE_RS09545">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09545">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949533.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15560" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15560" fbc:name="MASE_RS15560" fbc:label="G_MASE_RS15560">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15560">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950695.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17475" fbc:name="MASE_RS17475" fbc:label="G_MASE_RS17475">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17475">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951029.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16745" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16745" fbc:name="MASE_RS16745" fbc:label="G_MASE_RS16745">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16745">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950896.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07030" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07030" fbc:name="MASE_RS07030" fbc:label="G_MASE_RS07030">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07030">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949049.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13525" fbc:name="MASE_RS13525" fbc:label="G_MASE_RS13525">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13525">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950306.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13535" fbc:name="MASE_RS13535" fbc:label="G_MASE_RS13535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950308.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14890" fbc:name="MASE_RS14890" fbc:label="G_MASE_RS14890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950567.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10485" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10485" fbc:name="MASE_RS10485" fbc:label="G_MASE_RS10485">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10485">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693510.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14725" fbc:name="MASE_RS14725" fbc:label="G_MASE_RS14725">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14725">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950534.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09570" fbc:name="MASE_RS09570" fbc:label="G_MASE_RS09570">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09570">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693493.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07235" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07235" fbc:name="MASE_RS07235" fbc:label="G_MASE_RS07235">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07235">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949088.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00090" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00090" fbc:name="MASE_RS00090" fbc:label="G_MASE_RS00090">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00090">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947725.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00095" fbc:name="MASE_RS00095" fbc:label="G_MASE_RS00095">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00095">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947726.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17745" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17745" fbc:name="MASE_RS17745" fbc:label="G_MASE_RS17745">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17745">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951081.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10135" fbc:name="MASE_RS10135" fbc:label="G_MASE_RS10135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949647.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07610" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07610" fbc:name="MASE_RS07610" fbc:label="G_MASE_RS07610">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07610">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949158.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12720" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12720" fbc:name="MASE_RS12720" fbc:label="G_MASE_RS12720">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12720">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950149.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03355" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03355" fbc:name="MASE_RS03355" fbc:label="G_MASE_RS03355">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03355">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948346.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10200" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10200" fbc:name="MASE_RS10200" fbc:label="G_MASE_RS10200">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10200">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949660.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09245" fbc:name="MASE_RS09245" fbc:label="G_MASE_RS09245">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09245">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949474.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15245" fbc:name="MASE_RS15245" fbc:label="G_MASE_RS15245">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15245">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950633.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02440" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02440" fbc:name="MASE_RS02440" fbc:label="G_MASE_RS02440">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02440">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948170.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04415" fbc:name="MASE_RS04415" fbc:label="G_MASE_RS04415">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04415">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948556.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13510" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13510" fbc:name="MASE_RS13510" fbc:label="G_MASE_RS13510">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13510">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950303.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13020" fbc:name="MASE_RS13020" fbc:label="G_MASE_RS13020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950207.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17605" fbc:name="MASE_RS17605" fbc:label="G_MASE_RS17605">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17605">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951053.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08060" fbc:name="MASE_RS08060" fbc:label="G_MASE_RS08060">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08060">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949242.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12330" fbc:name="MASE_RS12330" fbc:label="G_MASE_RS12330">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12330">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950078.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03630" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03630" fbc:name="MASE_RS03630" fbc:label="G_MASE_RS03630">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03630">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948401.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03010" fbc:name="MASE_RS03010" fbc:label="G_MASE_RS03010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948283.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03635" fbc:name="MASE_RS03635" fbc:label="G_MASE_RS03635">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03635">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948402.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09660" fbc:name="MASE_RS09660" fbc:label="G_MASE_RS09660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949556.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05060" fbc:name="MASE_RS05060" fbc:label="G_MASE_RS05060">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05060">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948676.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02815" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02815" fbc:name="MASE_RS02815" fbc:label="G_MASE_RS02815">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02815">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948245.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12990" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12990" fbc:name="MASE_RS12990" fbc:label="G_MASE_RS12990">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12990">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950201.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17360" fbc:name="MASE_RS17360" fbc:label="G_MASE_RS17360">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17360">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951007.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17960" fbc:name="MASE_RS17960" fbc:label="G_MASE_RS17960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951122.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16515" fbc:name="MASE_RS16515" fbc:label="G_MASE_RS16515">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16515">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950852.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06280" fbc:name="MASE_RS06280" fbc:label="G_MASE_RS06280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948912.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08380" fbc:name="MASE_RS08380" fbc:label="G_MASE_RS08380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949304.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04260" fbc:name="MASE_RS04260" fbc:label="G_MASE_RS04260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948525.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06395" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06395" fbc:name="MASE_RS06395" fbc:label="G_MASE_RS06395">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06395">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948931.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00570" fbc:name="MASE_RS00570" fbc:label="G_MASE_RS00570">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00570">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947814.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17565" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17565" fbc:name="MASE_RS17565" fbc:label="G_MASE_RS17565">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17565">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951046.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09115" fbc:name="MASE_RS09115" fbc:label="G_MASE_RS09115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949449.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06110" fbc:name="MASE_RS06110" fbc:label="G_MASE_RS06110">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06110">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948878.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11655" fbc:name="MASE_RS11655" fbc:label="G_MASE_RS11655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949948.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17205" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17205" fbc:name="MASE_RS17205" fbc:label="G_MASE_RS17205">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17205">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950978.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16215" fbc:name="MASE_RS16215" fbc:label="G_MASE_RS16215">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16215">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950802.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14720" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14720" fbc:name="MASE_RS14720" fbc:label="G_MASE_RS14720">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14720">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950533.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12615" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12615" fbc:name="MASE_RS12615" fbc:label="G_MASE_RS12615">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12615">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950132.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08705" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08705" fbc:name="MASE_RS08705" fbc:label="G_MASE_RS08705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949368.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03555" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03555" fbc:name="MASE_RS03555" fbc:label="G_MASE_RS03555">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03555">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948386.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07990" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07990" fbc:name="MASE_RS07990" fbc:label="G_MASE_RS07990">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07990">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949228.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14995" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14995" fbc:name="MASE_RS14995" fbc:label="G_MASE_RS14995">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14995">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950588.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02020" fbc:name="MASE_RS02020" fbc:label="G_MASE_RS02020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948092.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04470" fbc:name="MASE_RS04470" fbc:label="G_MASE_RS04470">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04470">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948567.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11640" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11640" fbc:name="MASE_RS11640" fbc:label="G_MASE_RS11640">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11640">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949945.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12745" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12745" fbc:name="MASE_RS12745" fbc:label="G_MASE_RS12745">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12745">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950154.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15790" fbc:name="MASE_RS15790" fbc:label="G_MASE_RS15790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950717.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00290" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00290" fbc:name="MASE_RS00290" fbc:label="G_MASE_RS00290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947760.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14860" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14860" fbc:name="MASE_RS14860" fbc:label="G_MASE_RS14860">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14860">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950561.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12095" fbc:name="MASE_RS12095" fbc:label="G_MASE_RS12095">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12095">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950034.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04115" fbc:name="MASE_RS04115" fbc:label="G_MASE_RS04115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948496.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11300" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11300" fbc:name="MASE_RS11300" fbc:label="G_MASE_RS11300">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11300">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949878.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11155" fbc:name="MASE_RS11155" fbc:label="G_MASE_RS11155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949849.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02780" fbc:name="MASE_RS02780" fbc:label="G_MASE_RS02780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948238.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02595" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02595" fbc:name="MASE_RS02595" fbc:label="G_MASE_RS02595">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02595">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948200.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16555" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16555" fbc:name="MASE_RS16555" fbc:label="G_MASE_RS16555">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16555">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950860.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01370" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01370" fbc:name="MASE_RS01370" fbc:label="G_MASE_RS01370">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01370">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947969.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05105" fbc:name="MASE_RS05105" fbc:label="G_MASE_RS05105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948685.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00515" fbc:name="MASE_RS00515" fbc:label="G_MASE_RS00515">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00515">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947804.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03240" fbc:name="MASE_RS03240" fbc:label="G_MASE_RS03240">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03240">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948325.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17115" fbc:name="MASE_RS17115" fbc:label="G_MASE_RS17115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_375342098.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18525" fbc:name="MASE_RS18525" fbc:label="G_MASE_RS18525">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18525">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951234.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12385" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12385" fbc:name="MASE_RS12385" fbc:label="G_MASE_RS12385">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12385">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950088.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19150" fbc:name="MASE_RS19150" fbc:label="G_MASE_RS19150">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19150">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951354.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08445" fbc:name="MASE_RS08445" fbc:label="G_MASE_RS08445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949316.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10615" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10615" fbc:name="MASE_RS10615" fbc:label="G_MASE_RS10615">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10615">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949742.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05930" fbc:name="MASE_RS05930" fbc:label="G_MASE_RS05930">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05930">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948845.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04295" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04295" fbc:name="MASE_RS04295" fbc:label="G_MASE_RS04295">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04295">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948532.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18335" fbc:name="MASE_RS18335" fbc:label="G_MASE_RS18335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951198.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01585" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01585" fbc:name="MASE_RS01585" fbc:label="G_MASE_RS01585">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01585">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948008.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13920" fbc:name="MASE_RS13920" fbc:label="G_MASE_RS13920">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13920">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950385.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00155" fbc:name="MASE_RS00155" fbc:label="G_MASE_RS00155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947738.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14870" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14870" fbc:name="MASE_RS14870" fbc:label="G_MASE_RS14870">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14870">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950563.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16250" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16250" fbc:name="MASE_RS16250" fbc:label="G_MASE_RS16250">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16250">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950809.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11570" fbc:name="MASE_RS11570" fbc:label="G_MASE_RS11570">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11570">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949931.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16210" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16210" fbc:name="MASE_RS16210" fbc:label="G_MASE_RS16210">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16210">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950801.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13900" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13900" fbc:name="MASE_RS13900" fbc:label="G_MASE_RS13900">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13900">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950381.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11620" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11620" fbc:name="MASE_RS11620" fbc:label="G_MASE_RS11620">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11620">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949941.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02400" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02400" fbc:name="MASE_RS02400" fbc:label="G_MASE_RS02400">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02400">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948162.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03220" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03220" fbc:name="MASE_RS03220" fbc:label="G_MASE_RS03220">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03220">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948321.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02475" fbc:name="MASE_RS02475" fbc:label="G_MASE_RS02475">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02475">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948176.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12085" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12085" fbc:name="MASE_RS12085" fbc:label="G_MASE_RS12085">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12085">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950032.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19455" fbc:name="MASE_RS19455" fbc:label="G_MASE_RS19455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951402.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13810" fbc:name="MASE_RS13810" fbc:label="G_MASE_RS13810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950363.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11605" fbc:name="MASE_RS11605" fbc:label="G_MASE_RS11605">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11605">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949938.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09120" fbc:name="MASE_RS09120" fbc:label="G_MASE_RS09120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949450.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09125" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09125" fbc:name="MASE_RS09125" fbc:label="G_MASE_RS09125">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09125">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518366.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09640" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09640" fbc:name="MASE_RS09640" fbc:label="G_MASE_RS09640">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09640">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949552.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11695" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11695" fbc:name="MASE_RS11695" fbc:label="G_MASE_RS11695">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11695">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949954.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00325" fbc:name="MASE_RS00325" fbc:label="G_MASE_RS00325">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00325">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947767.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03795" fbc:name="MASE_RS03795" fbc:label="G_MASE_RS03795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693681.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19420" fbc:name="MASE_RS19420" fbc:label="G_MASE_RS19420">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19420">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693681.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18985" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18985" fbc:name="MASE_RS18985" fbc:label="G_MASE_RS18985">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18985">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951321.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05130" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05130" fbc:name="MASE_RS05130" fbc:label="G_MASE_RS05130">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05130">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948690.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02170" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02170" fbc:name="MASE_RS02170" fbc:label="G_MASE_RS02170">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02170">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948119.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01120" fbc:name="MASE_RS01120" fbc:label="G_MASE_RS01120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947924.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13290" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13290" fbc:name="MASE_RS13290" fbc:label="G_MASE_RS13290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950261.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01330" fbc:name="MASE_RS01330" fbc:label="G_MASE_RS01330">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01330">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947964.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS19195" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19195" fbc:name="MASE_RS19195" fbc:label="G_MASE_RS19195"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16580" fbc:name="MASE_RS16580" fbc:label="G_MASE_RS16580"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00345" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00345" fbc:name="MASE_RS00345" fbc:label="G_MASE_RS00345"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06710" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06710" fbc:name="MASE_RS06710" fbc:label="G_MASE_RS06710"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05525" fbc:name="MASE_RS05525" fbc:label="G_MASE_RS05525"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14415" fbc:name="MASE_RS14415" fbc:label="G_MASE_RS14415"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13975" fbc:name="MASE_RS13975" fbc:label="G_MASE_RS13975"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09480" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09480" fbc:name="MASE_RS09480" fbc:label="G_MASE_RS09480"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09475" fbc:name="MASE_RS09475" fbc:label="G_MASE_RS09475"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18570" fbc:name="MASE_RS18570" fbc:label="G_MASE_RS18570"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10755" fbc:name="MASE_RS10755" fbc:label="G_MASE_RS10755"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10840" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10840" fbc:name="MASE_RS10840" fbc:label="G_MASE_RS10840"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19175" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19175" fbc:name="MASE_RS19175" fbc:label="G_MASE_RS19175"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18080" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18080" fbc:name="MASE_RS18080" fbc:label="G_MASE_RS18080"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06505" fbc:name="MASE_RS06505" fbc:label="G_MASE_RS06505"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04455" fbc:name="MASE_RS04455" fbc:label="G_MASE_RS04455"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10500" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10500" fbc:name="MASE_RS10500" fbc:label="G_MASE_RS10500"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09955" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09955" fbc:name="MASE_RS09955" fbc:label="G_MASE_RS09955"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14485" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14485" fbc:name="MASE_RS14485" fbc:label="G_MASE_RS14485"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19825" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19825" fbc:name="MASE_RS19825" fbc:label="G_MASE_RS19825"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01645" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01645" fbc:name="MASE_RS01645" fbc:label="G_MASE_RS01645"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02670" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02670" fbc:name="MASE_RS02670" fbc:label="G_MASE_RS02670"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07775" fbc:name="MASE_RS07775" fbc:label="G_MASE_RS07775"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01910" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01910" fbc:name="MASE_RS01910" fbc:label="G_MASE_RS01910"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06855" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06855" fbc:name="MASE_RS06855" fbc:label="G_MASE_RS06855"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03550" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03550" fbc:name="MASE_RS03550" fbc:label="G_MASE_RS03550"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02120" fbc:name="MASE_RS02120" fbc:label="G_MASE_RS02120"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04980" fbc:name="MASE_RS04980" fbc:label="G_MASE_RS04980"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08740" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08740" fbc:name="MASE_RS08740" fbc:label="G_MASE_RS08740"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01820" fbc:name="MASE_RS01820" fbc:label="G_MASE_RS01820"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10680" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10680" fbc:name="MASE_RS10680" fbc:label="G_MASE_RS10680"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11290" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11290" fbc:name="MASE_RS11290" fbc:label="G_MASE_RS11290"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05500" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05500" fbc:name="MASE_RS05500" fbc:label="G_MASE_RS05500"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01410" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01410" fbc:name="MASE_RS01410" fbc:label="G_MASE_RS01410"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15060" fbc:name="MASE_RS15060" fbc:label="G_MASE_RS15060"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01420" fbc:name="MASE_RS01420" fbc:label="G_MASE_RS01420"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16805" fbc:name="MASE_RS16805" fbc:label="G_MASE_RS16805"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12610" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12610" fbc:name="MASE_RS12610" fbc:label="G_MASE_RS12610"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16865" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16865" fbc:name="MASE_RS16865" fbc:label="G_MASE_RS16865"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04395" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04395" fbc:name="MASE_RS04395" fbc:label="G_MASE_RS04395"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08155" fbc:name="MASE_RS08155" fbc:label="G_MASE_RS08155"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16835" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16835" fbc:name="MASE_RS16835" fbc:label="G_MASE_RS16835"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06205" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06205" fbc:name="MASE_RS06205" fbc:label="G_MASE_RS06205"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16840" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16840" fbc:name="MASE_RS16840" fbc:label="G_MASE_RS16840"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12805" fbc:name="MASE_RS12805" fbc:label="G_MASE_RS12805"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01445" fbc:name="MASE_RS01445" fbc:label="G_MASE_RS01445"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16855" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16855" fbc:name="MASE_RS16855" fbc:label="G_MASE_RS16855"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14850" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14850" fbc:name="MASE_RS14850" fbc:label="G_MASE_RS14850"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03260" fbc:name="MASE_RS03260" fbc:label="G_MASE_RS03260"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02335" fbc:name="MASE_RS02335" fbc:label="G_MASE_RS02335"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17950" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17950" fbc:name="MASE_RS17950" fbc:label="G_MASE_RS17950"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01415" fbc:name="MASE_RS01415" fbc:label="G_MASE_RS01415"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16795" fbc:name="MASE_RS16795" fbc:label="G_MASE_RS16795"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08650" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08650" fbc:name="MASE_RS08650" fbc:label="G_MASE_RS08650"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16815" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16815" fbc:name="MASE_RS16815" fbc:label="G_MASE_RS16815"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06830" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06830" fbc:name="MASE_RS06830" fbc:label="G_MASE_RS06830"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07300" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07300" fbc:name="MASE_RS07300" fbc:label="G_MASE_RS07300"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01450" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01450" fbc:name="MASE_RS01450" fbc:label="G_MASE_RS01450"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01430" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01430" fbc:name="MASE_RS01430" fbc:label="G_MASE_RS01430"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00105" fbc:name="MASE_RS00105" fbc:label="G_MASE_RS00105"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17190" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17190" fbc:name="MASE_RS17190" fbc:label="G_MASE_RS17190"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01435" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01435" fbc:name="MASE_RS01435" fbc:label="G_MASE_RS01435"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11475" fbc:name="MASE_RS11475" fbc:label="G_MASE_RS11475"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16830" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16830" fbc:name="MASE_RS16830" fbc:label="G_MASE_RS16830"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06345" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06345" fbc:name="MASE_RS06345" fbc:label="G_MASE_RS06345"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16810" fbc:name="MASE_RS16810" fbc:label="G_MASE_RS16810"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01665" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01665" fbc:name="MASE_RS01665" fbc:label="G_MASE_RS01665"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05440" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05440" fbc:name="MASE_RS05440" fbc:label="G_MASE_RS05440"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12625" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12625" fbc:name="MASE_RS12625" fbc:label="G_MASE_RS12625"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05335" fbc:name="MASE_RS05335" fbc:label="G_MASE_RS05335"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04475" fbc:name="MASE_RS04475" fbc:label="G_MASE_RS04475"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00040" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00040" fbc:name="MASE_RS00040" fbc:label="G_MASE_RS00040"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19790" fbc:name="MASE_RS19790" fbc:label="G_MASE_RS19790"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17515" fbc:name="MASE_RS17515" fbc:label="G_MASE_RS17515"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16850" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16850" fbc:name="MASE_RS16850" fbc:label="G_MASE_RS16850"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17940" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17940" fbc:name="MASE_RS17940" fbc:label="G_MASE_RS17940"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02930" fbc:name="MASE_RS02930" fbc:label="G_MASE_RS02930"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01405" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01405" fbc:name="MASE_RS01405" fbc:label="G_MASE_RS01405"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02340" fbc:name="MASE_RS02340" fbc:label="G_MASE_RS02340"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17945" fbc:name="MASE_RS17945" fbc:label="G_MASE_RS17945"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05015" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05015" fbc:name="MASE_RS05015" fbc:label="G_MASE_RS05015"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17510" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17510" fbc:name="MASE_RS17510" fbc:label="G_MASE_RS17510"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07455" fbc:name="MASE_RS07455" fbc:label="G_MASE_RS07455"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17535" fbc:name="MASE_RS17535" fbc:label="G_MASE_RS17535"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05865" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05865" fbc:name="MASE_RS05865" fbc:label="G_MASE_RS05865"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10050" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10050" fbc:name="MASE_RS10050" fbc:label="G_MASE_RS10050"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07895" fbc:name="MASE_RS07895" fbc:label="G_MASE_RS07895"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00045" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00045" fbc:name="MASE_RS00045" fbc:label="G_MASE_RS00045"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00270" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00270" fbc:name="MASE_RS00270" fbc:label="G_MASE_RS00270"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01440" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01440" fbc:name="MASE_RS01440" fbc:label="G_MASE_RS01440"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17540" fbc:name="MASE_RS17540" fbc:label="G_MASE_RS17540"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16875" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16875" fbc:name="MASE_RS16875" fbc:label="G_MASE_RS16875"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05880" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05880" fbc:name="MASE_RS05880" fbc:label="G_MASE_RS05880"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03265" fbc:name="MASE_RS03265" fbc:label="G_MASE_RS03265"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06005" fbc:name="MASE_RS06005" fbc:label="G_MASE_RS06005"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07460" fbc:name="MASE_RS07460" fbc:label="G_MASE_RS07460"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01425" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01425" fbc:name="MASE_RS01425" fbc:label="G_MASE_RS01425"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16845" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16845" fbc:name="MASE_RS16845" fbc:label="G_MASE_RS16845"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17530" fbc:name="MASE_RS17530" fbc:label="G_MASE_RS17530"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07290" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07290" fbc:name="MASE_RS07290" fbc:label="G_MASE_RS07290"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00275" fbc:name="MASE_RS00275" fbc:label="G_MASE_RS00275"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11520" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11520" fbc:name="MASE_RS11520" fbc:label="G_MASE_RS11520"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17545" fbc:name="MASE_RS17545" fbc:label="G_MASE_RS17545"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07305" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07305" fbc:name="MASE_RS07305" fbc:label="G_MASE_RS07305"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01400" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01400" fbc:name="MASE_RS01400" fbc:label="G_MASE_RS01400"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16860" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16860" fbc:name="MASE_RS16860" fbc:label="G_MASE_RS16860"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16820" fbc:name="MASE_RS16820" fbc:label="G_MASE_RS16820"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16870" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16870" fbc:name="MASE_RS16870" fbc:label="G_MASE_RS16870"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04240" fbc:name="MASE_RS04240" fbc:label="G_MASE_RS04240"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00025" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00025" fbc:name="MASE_RS00025" fbc:label="G_MASE_RS00025"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07975" fbc:name="MASE_RS07975" fbc:label="G_MASE_RS07975"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06790" fbc:name="MASE_RS06790" fbc:label="G_MASE_RS06790"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04755" fbc:name="MASE_RS04755" fbc:label="G_MASE_RS04755"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00340" fbc:name="MASE_RS00340" fbc:label="G_MASE_RS00340"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01810" fbc:name="MASE_RS01810" fbc:label="G_MASE_RS01810"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14170" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14170" fbc:name="MASE_RS14170" fbc:label="G_MASE_RS14170"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06700" fbc:name="MASE_RS06700" fbc:label="G_MASE_RS06700"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03615" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03615" fbc:name="MASE_RS03615" fbc:label="G_MASE_RS03615"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16545" fbc:name="MASE_RS16545" fbc:label="G_MASE_RS16545"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04160" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04160" fbc:name="MASE_RS04160" fbc:label="G_MASE_RS04160"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07215" fbc:name="MASE_RS07215" fbc:label="G_MASE_RS07215"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18975" fbc:name="MASE_RS18975" fbc:label="G_MASE_RS18975"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12260" fbc:name="MASE_RS12260" fbc:label="G_MASE_RS12260"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15565" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15565" fbc:name="MASE_RS15565" fbc:label="G_MASE_RS15565"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09235" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09235" fbc:name="MASE_RS09235" fbc:label="G_MASE_RS09235"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13895" fbc:name="MASE_RS13895" fbc:label="G_MASE_RS13895"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16065" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16065" fbc:name="MASE_RS16065" fbc:label="G_MASE_RS16065"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16405" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16405" fbc:name="MASE_RS16405" fbc:label="G_MASE_RS16405"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11410" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11410" fbc:name="MASE_RS11410" fbc:label="G_MASE_RS11410"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01760" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01760" fbc:name="MASE_RS01760" fbc:label="G_MASE_RS01760"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09285" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09285" fbc:name="MASE_RS09285" fbc:label="G_MASE_RS09285"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15635" fbc:name="MASE_RS15635" fbc:label="G_MASE_RS15635"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12090" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12090" fbc:name="MASE_RS12090" fbc:label="G_MASE_RS12090"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12080" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12080" fbc:name="MASE_RS12080" fbc:label="G_MASE_RS12080"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11165" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11165" fbc:name="MASE_RS11165" fbc:label="G_MASE_RS11165"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13915" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13915" fbc:name="MASE_RS13915" fbc:label="G_MASE_RS13915"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10190" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10190" fbc:name="MASE_RS10190" fbc:label="G_MASE_RS10190"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13995" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13995" fbc:name="MASE_RS13995" fbc:label="G_MASE_RS13995"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17815" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17815" fbc:name="MASE_RS17815" fbc:label="G_MASE_RS17815"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14765" fbc:name="MASE_RS14765" fbc:label="G_MASE_RS14765"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11305" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11305" fbc:name="MASE_RS11305" fbc:label="G_MASE_RS11305"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04110" fbc:name="MASE_RS04110" fbc:label="G_MASE_RS04110"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01670" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01670" fbc:name="MASE_RS01670" fbc:label="G_MASE_RS01670"/>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16580" fbc:name="MASE_RS16580" fbc:label="G_MASE_RS16580">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16580">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693573.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00345" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00345" fbc:name="MASE_RS00345" fbc:label="G_MASE_RS00345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947771.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06710" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06710" fbc:name="MASE_RS06710" fbc:label="G_MASE_RS06710">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06710">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948990.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05525" fbc:name="MASE_RS05525" fbc:label="G_MASE_RS05525">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05525">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948764.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14415" fbc:name="MASE_RS14415" fbc:label="G_MASE_RS14415">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14415">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950473.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13975" fbc:name="MASE_RS13975" fbc:label="G_MASE_RS13975">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13975">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950395.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09480" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09480" fbc:name="MASE_RS09480" fbc:label="G_MASE_RS09480">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09480">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949520.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09475" fbc:name="MASE_RS09475" fbc:label="G_MASE_RS09475">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09475">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949519.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18570" fbc:name="MASE_RS18570" fbc:label="G_MASE_RS18570">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18570">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951242.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10755" fbc:name="MASE_RS10755" fbc:label="G_MASE_RS10755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949768.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10840" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10840" fbc:name="MASE_RS10840" fbc:label="G_MASE_RS10840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949785.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19175" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19175" fbc:name="MASE_RS19175" fbc:label="G_MASE_RS19175">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19175">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951359.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18080" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18080" fbc:name="MASE_RS18080" fbc:label="G_MASE_RS18080">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18080">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951146.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06505" fbc:name="MASE_RS06505" fbc:label="G_MASE_RS06505">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06505">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948951.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04455" fbc:name="MASE_RS04455" fbc:label="G_MASE_RS04455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948564.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10500" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10500" fbc:name="MASE_RS10500" fbc:label="G_MASE_RS10500">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10500">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949721.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09955" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09955" fbc:name="MASE_RS09955" fbc:label="G_MASE_RS09955">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09955">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949612.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14485" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14485" fbc:name="MASE_RS14485" fbc:label="G_MASE_RS14485">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14485">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950486.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19825" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19825" fbc:name="MASE_RS19825" fbc:label="G_MASE_RS19825">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19825">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949920.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01645" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01645" fbc:name="MASE_RS01645" fbc:label="G_MASE_RS01645">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01645">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948020.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02670" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02670" fbc:name="MASE_RS02670" fbc:label="G_MASE_RS02670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948216.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07775" fbc:name="MASE_RS07775" fbc:label="G_MASE_RS07775">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07775">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949187.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01910" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01910" fbc:name="MASE_RS01910" fbc:label="G_MASE_RS01910">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01910">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232362840.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06855" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06855" fbc:name="MASE_RS06855" fbc:label="G_MASE_RS06855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949015.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03550" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03550" fbc:name="MASE_RS03550" fbc:label="G_MASE_RS03550">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03550">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948385.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02120" fbc:name="MASE_RS02120" fbc:label="G_MASE_RS02120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948109.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04980" fbc:name="MASE_RS04980" fbc:label="G_MASE_RS04980">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04980">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948664.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08740" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08740" fbc:name="MASE_RS08740" fbc:label="G_MASE_RS08740">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08740">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949374.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01820" fbc:name="MASE_RS01820" fbc:label="G_MASE_RS01820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948054.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10680" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10680" fbc:name="MASE_RS10680" fbc:label="G_MASE_RS10680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949753.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11290" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11290" fbc:name="MASE_RS11290" fbc:label="G_MASE_RS11290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949876.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05500" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05500" fbc:name="MASE_RS05500" fbc:label="G_MASE_RS05500">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05500">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948759.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01410" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01410" fbc:name="MASE_RS01410" fbc:label="G_MASE_RS01410">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01410">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516958.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15060" fbc:name="MASE_RS15060" fbc:label="G_MASE_RS15060">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15060">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950601.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01420" fbc:name="MASE_RS01420" fbc:label="G_MASE_RS01420">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01420">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947976.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16805" fbc:name="MASE_RS16805" fbc:label="G_MASE_RS16805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519214.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12610" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12610" fbc:name="MASE_RS12610" fbc:label="G_MASE_RS12610">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12610">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950131.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16865" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16865" fbc:name="MASE_RS16865" fbc:label="G_MASE_RS16865">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16865">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950911.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04395" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04395" fbc:name="MASE_RS04395" fbc:label="G_MASE_RS04395">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04395">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948552.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08155" fbc:name="MASE_RS08155" fbc:label="G_MASE_RS08155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518257.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16835" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16835" fbc:name="MASE_RS16835" fbc:label="G_MASE_RS16835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950907.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06205" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06205" fbc:name="MASE_RS06205" fbc:label="G_MASE_RS06205">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06205">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948897.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16840" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16840" fbc:name="MASE_RS16840" fbc:label="G_MASE_RS16840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519221.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12805" fbc:name="MASE_RS12805" fbc:label="G_MASE_RS12805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950166.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01445" fbc:name="MASE_RS01445" fbc:label="G_MASE_RS01445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947980.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16855" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16855" fbc:name="MASE_RS16855" fbc:label="G_MASE_RS16855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519224.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14850" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14850" fbc:name="MASE_RS14850" fbc:label="G_MASE_RS14850">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14850">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950559.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03260" fbc:name="MASE_RS03260" fbc:label="G_MASE_RS03260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948329.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02335" fbc:name="MASE_RS02335" fbc:label="G_MASE_RS02335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012517169.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17950" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17950" fbc:name="MASE_RS17950" fbc:label="G_MASE_RS17950">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17950">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951120.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01415" fbc:name="MASE_RS01415" fbc:label="G_MASE_RS01415">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01415">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516959.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16795" fbc:name="MASE_RS16795" fbc:label="G_MASE_RS16795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519212.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08650" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08650" fbc:name="MASE_RS08650" fbc:label="G_MASE_RS08650">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08650">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949357.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16815" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16815" fbc:name="MASE_RS16815" fbc:label="G_MASE_RS16815">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16815">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519216.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06830" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06830" fbc:name="MASE_RS06830" fbc:label="G_MASE_RS06830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949011.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07300" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07300" fbc:name="MASE_RS07300" fbc:label="G_MASE_RS07300">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07300">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518091.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01450" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01450" fbc:name="MASE_RS01450" fbc:label="G_MASE_RS01450">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01450">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947981.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01430" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01430" fbc:name="MASE_RS01430" fbc:label="G_MASE_RS01430">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01430">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947977.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00105" fbc:name="MASE_RS00105" fbc:label="G_MASE_RS00105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947728.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17190" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17190" fbc:name="MASE_RS17190" fbc:label="G_MASE_RS17190">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17190">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950975.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01435" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01435" fbc:name="MASE_RS01435" fbc:label="G_MASE_RS01435">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01435">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947978.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11475" fbc:name="MASE_RS11475" fbc:label="G_MASE_RS11475">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11475">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949913.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16830" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16830" fbc:name="MASE_RS16830" fbc:label="G_MASE_RS16830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950906.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06345" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06345" fbc:name="MASE_RS06345" fbc:label="G_MASE_RS06345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948924.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16810" fbc:name="MASE_RS16810" fbc:label="G_MASE_RS16810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519215.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01665" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01665" fbc:name="MASE_RS01665" fbc:label="G_MASE_RS01665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948024.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05440" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05440" fbc:name="MASE_RS05440" fbc:label="G_MASE_RS05440">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05440">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948748.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12625" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12625" fbc:name="MASE_RS12625" fbc:label="G_MASE_RS12625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950134.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05335" fbc:name="MASE_RS05335" fbc:label="G_MASE_RS05335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948727.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04475" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04475" fbc:name="MASE_RS04475" fbc:label="G_MASE_RS04475">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04475">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948568.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00040" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00040" fbc:name="MASE_RS00040" fbc:label="G_MASE_RS00040">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00040">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947715.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19790" fbc:name="MASE_RS19790" fbc:label="G_MASE_RS19790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014290886.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17515" fbc:name="MASE_RS17515" fbc:label="G_MASE_RS17515">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17515">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951037.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16850" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16850" fbc:name="MASE_RS16850" fbc:label="G_MASE_RS16850">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16850">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950909.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17940" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17940" fbc:name="MASE_RS17940" fbc:label="G_MASE_RS17940">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17940">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519953.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02930" fbc:name="MASE_RS02930" fbc:label="G_MASE_RS02930">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02930">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012517258.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01405" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01405" fbc:name="MASE_RS01405" fbc:label="G_MASE_RS01405">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01405">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947975.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02340" fbc:name="MASE_RS02340" fbc:label="G_MASE_RS02340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012517170.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17945" fbc:name="MASE_RS17945" fbc:label="G_MASE_RS17945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519954.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05015" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05015" fbc:name="MASE_RS05015" fbc:label="G_MASE_RS05015">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05015">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948671.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17510" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17510" fbc:name="MASE_RS17510" fbc:label="G_MASE_RS17510">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17510">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951036.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07455" fbc:name="MASE_RS07455" fbc:label="G_MASE_RS07455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518127.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17535" fbc:name="MASE_RS17535" fbc:label="G_MASE_RS17535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951041.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05865" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05865" fbc:name="MASE_RS05865" fbc:label="G_MASE_RS05865">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05865">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948832.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10050" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10050" fbc:name="MASE_RS10050" fbc:label="G_MASE_RS10050">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10050">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949630.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07895" fbc:name="MASE_RS07895" fbc:label="G_MASE_RS07895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518206.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00045" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00045" fbc:name="MASE_RS00045" fbc:label="G_MASE_RS00045">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00045">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947716.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00270" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00270" fbc:name="MASE_RS00270" fbc:label="G_MASE_RS00270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947757.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01440" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01440" fbc:name="MASE_RS01440" fbc:label="G_MASE_RS01440">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01440">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947979.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17540" fbc:name="MASE_RS17540" fbc:label="G_MASE_RS17540">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17540">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951042.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16875" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16875" fbc:name="MASE_RS16875" fbc:label="G_MASE_RS16875">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16875">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519228.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05880" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05880" fbc:name="MASE_RS05880" fbc:label="G_MASE_RS05880">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05880">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_024015986.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03265" fbc:name="MASE_RS03265" fbc:label="G_MASE_RS03265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948330.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06005" fbc:name="MASE_RS06005" fbc:label="G_MASE_RS06005">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948860.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07460" fbc:name="MASE_RS07460" fbc:label="G_MASE_RS07460">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07460">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949128.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01425" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01425" fbc:name="MASE_RS01425" fbc:label="G_MASE_RS01425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516961.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16845" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16845" fbc:name="MASE_RS16845" fbc:label="G_MASE_RS16845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950908.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17530" fbc:name="MASE_RS17530" fbc:label="G_MASE_RS17530">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17530">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_015068303.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07290" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07290" fbc:name="MASE_RS07290" fbc:label="G_MASE_RS07290">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07290">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949098.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00275" fbc:name="MASE_RS00275" fbc:label="G_MASE_RS00275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516577.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11520" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11520" fbc:name="MASE_RS11520" fbc:label="G_MASE_RS11520">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11520">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949921.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17545" fbc:name="MASE_RS17545" fbc:label="G_MASE_RS17545">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17545">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951043.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07305" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07305" fbc:name="MASE_RS07305" fbc:label="G_MASE_RS07305">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07305">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012518092.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01400" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01400" fbc:name="MASE_RS01400" fbc:label="G_MASE_RS01400">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01400">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_010179497.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16860" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16860" fbc:name="MASE_RS16860" fbc:label="G_MASE_RS16860">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16860">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950910.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16820" fbc:name="MASE_RS16820" fbc:label="G_MASE_RS16820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519217.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16870" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16870" fbc:name="MASE_RS16870" fbc:label="G_MASE_RS16870">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16870">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950912.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04240" fbc:name="MASE_RS04240" fbc:label="G_MASE_RS04240">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04240">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948521.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00025" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00025" fbc:name="MASE_RS00025" fbc:label="G_MASE_RS00025">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00025">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947712.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07975" fbc:name="MASE_RS07975" fbc:label="G_MASE_RS07975">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07975">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949225.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06790" fbc:name="MASE_RS06790" fbc:label="G_MASE_RS06790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949007.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04755" fbc:name="MASE_RS04755" fbc:label="G_MASE_RS04755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948622.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00340" fbc:name="MASE_RS00340" fbc:label="G_MASE_RS00340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693341.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01810" fbc:name="MASE_RS01810" fbc:label="G_MASE_RS01810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948052.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14170" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14170" fbc:name="MASE_RS14170" fbc:label="G_MASE_RS14170">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14170">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950434.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06700" fbc:name="MASE_RS06700" fbc:label="G_MASE_RS06700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948988.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03615" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03615" fbc:name="MASE_RS03615" fbc:label="G_MASE_RS03615">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03615">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948398.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16545" fbc:name="MASE_RS16545" fbc:label="G_MASE_RS16545">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16545">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950858.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04160" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04160" fbc:name="MASE_RS04160" fbc:label="G_MASE_RS04160">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04160">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948505.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07215" fbc:name="MASE_RS07215" fbc:label="G_MASE_RS07215">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07215">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949084.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18975" fbc:name="MASE_RS18975" fbc:label="G_MASE_RS18975">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18975">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951319.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12260" fbc:name="MASE_RS12260" fbc:label="G_MASE_RS12260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950063.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15565" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15565" fbc:name="MASE_RS15565" fbc:label="G_MASE_RS15565">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15565">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950696.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09235" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09235" fbc:name="MASE_RS09235" fbc:label="G_MASE_RS09235">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09235">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949472.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13895" fbc:name="MASE_RS13895" fbc:label="G_MASE_RS13895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950380.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16065" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16065" fbc:name="MASE_RS16065" fbc:label="G_MASE_RS16065">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16065">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950772.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16405" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16405" fbc:name="MASE_RS16405" fbc:label="G_MASE_RS16405">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16405">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950840.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11410" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11410" fbc:name="MASE_RS11410" fbc:label="G_MASE_RS11410">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11410">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693780.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01760" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01760" fbc:name="MASE_RS01760" fbc:label="G_MASE_RS01760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948043.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09285" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09285" fbc:name="MASE_RS09285" fbc:label="G_MASE_RS09285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949482.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15635" fbc:name="MASE_RS15635" fbc:label="G_MASE_RS15635">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15635">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949482.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12090" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12090" fbc:name="MASE_RS12090" fbc:label="G_MASE_RS12090">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12090">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950033.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12080" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12080" fbc:name="MASE_RS12080" fbc:label="G_MASE_RS12080">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12080">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950031.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11165" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11165" fbc:name="MASE_RS11165" fbc:label="G_MASE_RS11165">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11165">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949851.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13915" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13915" fbc:name="MASE_RS13915" fbc:label="G_MASE_RS13915">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13915">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232362770.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10190" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10190" fbc:name="MASE_RS10190" fbc:label="G_MASE_RS10190">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10190">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949658.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13995" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13995" fbc:name="MASE_RS13995" fbc:label="G_MASE_RS13995">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13995">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950399.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17815" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17815" fbc:name="MASE_RS17815" fbc:label="G_MASE_RS17815">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17815">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951095.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14765" fbc:name="MASE_RS14765" fbc:label="G_MASE_RS14765">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14765">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950542.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11305" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11305" fbc:name="MASE_RS11305" fbc:label="G_MASE_RS11305">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11305">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949879.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04110" fbc:name="MASE_RS04110" fbc:label="G_MASE_RS04110">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04110">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948495.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01670" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01670" fbc:name="MASE_RS01670" fbc:label="G_MASE_RS01670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948025.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS04055" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04055" fbc:name="MASE_RS04055" fbc:label="G_MASE_RS04055"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04050" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04050" fbc:name="MASE_RS04050" fbc:label="G_MASE_RS04050"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04060" fbc:name="MASE_RS04060" fbc:label="G_MASE_RS04060"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13310" fbc:name="MASE_RS13310" fbc:label="G_MASE_RS13310"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14005" fbc:name="MASE_RS14005" fbc:label="G_MASE_RS14005"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04205" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04205" fbc:name="MASE_RS04205" fbc:label="G_MASE_RS04205"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04190" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04190" fbc:name="MASE_RS04190" fbc:label="G_MASE_RS04190"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04195" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04195" fbc:name="MASE_RS04195" fbc:label="G_MASE_RS04195"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04200" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04200" fbc:name="MASE_RS04200" fbc:label="G_MASE_RS04200"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15910" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15910" fbc:name="MASE_RS15910" fbc:label="G_MASE_RS15910"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14425" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14425" fbc:name="MASE_RS14425" fbc:label="G_MASE_RS14425"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09580" fbc:name="MASE_RS09580" fbc:label="G_MASE_RS09580"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06570" fbc:name="MASE_RS06570" fbc:label="G_MASE_RS06570"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04150" fbc:name="MASE_RS04150" fbc:label="G_MASE_RS04150"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18995" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18995" fbc:name="MASE_RS18995" fbc:label="G_MASE_RS18995"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03315" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03315" fbc:name="MASE_RS03315" fbc:label="G_MASE_RS03315"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03205" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03205" fbc:name="MASE_RS03205" fbc:label="G_MASE_RS03205"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14140" fbc:name="MASE_RS14140" fbc:label="G_MASE_RS14140"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02860" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02860" fbc:name="MASE_RS02860" fbc:label="G_MASE_RS02860"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18830" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18830" fbc:name="MASE_RS18830" fbc:label="G_MASE_RS18830"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01375" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01375" fbc:name="MASE_RS01375" fbc:label="G_MASE_RS01375"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14380" fbc:name="MASE_RS14380" fbc:label="G_MASE_RS14380"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08200" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08200" fbc:name="MASE_RS08200" fbc:label="G_MASE_RS08200"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08205" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08205" fbc:name="MASE_RS08205" fbc:label="G_MASE_RS08205"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09730" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09730" fbc:name="MASE_RS09730" fbc:label="G_MASE_RS09730"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02060" fbc:name="MASE_RS02060" fbc:label="G_MASE_RS02060"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19540" fbc:name="MASE_RS19540" fbc:label="G_MASE_RS19540"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11245" fbc:name="MASE_RS11245" fbc:label="G_MASE_RS11245"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13010" fbc:name="MASE_RS13010" fbc:label="G_MASE_RS13010"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14325" fbc:name="MASE_RS14325" fbc:label="G_MASE_RS14325"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16905" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16905" fbc:name="MASE_RS16905" fbc:label="G_MASE_RS16905"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03455" fbc:name="MASE_RS03455" fbc:label="G_MASE_RS03455"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10265" fbc:name="MASE_RS10265" fbc:label="G_MASE_RS10265"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06735" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06735" fbc:name="MASE_RS06735" fbc:label="G_MASE_RS06735"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13815" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13815" fbc:name="MASE_RS13815" fbc:label="G_MASE_RS13815"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03790" fbc:name="MASE_RS03790" fbc:label="G_MASE_RS03790"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19415" fbc:name="MASE_RS19415" fbc:label="G_MASE_RS19415"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12415" fbc:name="MASE_RS12415" fbc:label="G_MASE_RS12415"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00760" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00760" fbc:name="MASE_RS00760" fbc:label="G_MASE_RS00760"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02620" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02620" fbc:name="MASE_RS02620" fbc:label="G_MASE_RS02620"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06680" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06680" fbc:name="MASE_RS06680" fbc:label="G_MASE_RS06680"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17700" fbc:name="MASE_RS17700" fbc:label="G_MASE_RS17700"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10765" fbc:name="MASE_RS10765" fbc:label="G_MASE_RS10765"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11125" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11125" fbc:name="MASE_RS11125" fbc:label="G_MASE_RS11125"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07230" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07230" fbc:name="MASE_RS07230" fbc:label="G_MASE_RS07230"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07600" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07600" fbc:name="MASE_RS07600" fbc:label="G_MASE_RS07600"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06240" fbc:name="MASE_RS06240" fbc:label="G_MASE_RS06240"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01640" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01640" fbc:name="MASE_RS01640" fbc:label="G_MASE_RS01640"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18840" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18840" fbc:name="MASE_RS18840" fbc:label="G_MASE_RS18840"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06650" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06650" fbc:name="MASE_RS06650" fbc:label="G_MASE_RS06650"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06655" fbc:name="MASE_RS06655" fbc:label="G_MASE_RS06655"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13005" fbc:name="MASE_RS13005" fbc:label="G_MASE_RS13005"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06455" fbc:name="MASE_RS06455" fbc:label="G_MASE_RS06455"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12440" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12440" fbc:name="MASE_RS12440" fbc:label="G_MASE_RS12440"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05115" fbc:name="MASE_RS05115" fbc:label="G_MASE_RS05115"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11930" fbc:name="MASE_RS11930" fbc:label="G_MASE_RS11930"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14780" fbc:name="MASE_RS14780" fbc:label="G_MASE_RS14780"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11660" fbc:name="MASE_RS11660" fbc:label="G_MASE_RS11660"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12395" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12395" fbc:name="MASE_RS12395" fbc:label="G_MASE_RS12395"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10145" fbc:name="MASE_RS10145" fbc:label="G_MASE_RS10145"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10140" fbc:name="MASE_RS10140" fbc:label="G_MASE_RS10140"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02175" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02175" fbc:name="MASE_RS02175" fbc:label="G_MASE_RS02175"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16585" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16585" fbc:name="MASE_RS16585" fbc:label="G_MASE_RS16585"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08735" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08735" fbc:name="MASE_RS08735" fbc:label="G_MASE_RS08735"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14775" fbc:name="MASE_RS14775" fbc:label="G_MASE_RS14775"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15145" fbc:name="MASE_RS15145" fbc:label="G_MASE_RS15145"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09960" fbc:name="MASE_RS09960" fbc:label="G_MASE_RS09960"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14770" fbc:name="MASE_RS14770" fbc:label="G_MASE_RS14770"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07555" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07555" fbc:name="MASE_RS07555" fbc:label="G_MASE_RS07555"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08635" fbc:name="MASE_RS08635" fbc:label="G_MASE_RS08635"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07620" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07620" fbc:name="MASE_RS07620" fbc:label="G_MASE_RS07620"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12400" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12400" fbc:name="MASE_RS12400" fbc:label="G_MASE_RS12400"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17020" fbc:name="MASE_RS17020" fbc:label="G_MASE_RS17020"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11790" fbc:name="MASE_RS11790" fbc:label="G_MASE_RS11790"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16335" fbc:name="MASE_RS16335" fbc:label="G_MASE_RS16335"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01590" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01590" fbc:name="MASE_RS01590" fbc:label="G_MASE_RS01590"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02965" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02965" fbc:name="MASE_RS02965" fbc:label="G_MASE_RS02965"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12265" fbc:name="MASE_RS12265" fbc:label="G_MASE_RS12265"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10080" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10080" fbc:name="MASE_RS10080" fbc:label="G_MASE_RS10080"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11170" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11170" fbc:name="MASE_RS11170" fbc:label="G_MASE_RS11170"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14235" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14235" fbc:name="MASE_RS14235" fbc:label="G_MASE_RS14235"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10470" fbc:name="MASE_RS10470" fbc:label="G_MASE_RS10470"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14285" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14285" fbc:name="MASE_RS14285" fbc:label="G_MASE_RS14285"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09240" fbc:name="MASE_RS09240" fbc:label="G_MASE_RS09240"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14115" fbc:name="MASE_RS14115" fbc:label="G_MASE_RS14115"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14465" fbc:name="MASE_RS14465" fbc:label="G_MASE_RS14465"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19160" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19160" fbc:name="MASE_RS19160" fbc:label="G_MASE_RS19160"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16450" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16450" fbc:name="MASE_RS16450" fbc:label="G_MASE_RS16450"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11465" fbc:name="MASE_RS11465" fbc:label="G_MASE_RS11465"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01740" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01740" fbc:name="MASE_RS01740" fbc:label="G_MASE_RS01740"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03215" fbc:name="MASE_RS03215" fbc:label="G_MASE_RS03215"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09520" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09520" fbc:name="MASE_RS09520" fbc:label="G_MASE_RS09520"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14930" fbc:name="MASE_RS14930" fbc:label="G_MASE_RS14930"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16665" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16665" fbc:name="MASE_RS16665" fbc:label="G_MASE_RS16665"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09020" fbc:name="MASE_RS09020" fbc:label="G_MASE_RS09020"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01980" fbc:name="MASE_RS01980" fbc:label="G_MASE_RS01980"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01975" fbc:name="MASE_RS01975" fbc:label="G_MASE_RS01975"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17760" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17760" fbc:name="MASE_RS17760" fbc:label="G_MASE_RS17760"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14480" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14480" fbc:name="MASE_RS14480" fbc:label="G_MASE_RS14480"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06460" fbc:name="MASE_RS06460" fbc:label="G_MASE_RS06460"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01580" fbc:name="MASE_RS01580" fbc:label="G_MASE_RS01580"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13470" fbc:name="MASE_RS13470" fbc:label="G_MASE_RS13470"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07720" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07720" fbc:name="MASE_RS07720" fbc:label="G_MASE_RS07720"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18340" fbc:name="MASE_RS18340" fbc:label="G_MASE_RS18340"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11285" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11285" fbc:name="MASE_RS11285" fbc:label="G_MASE_RS11285"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16460" fbc:name="MASE_RS16460" fbc:label="G_MASE_RS16460"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00140" fbc:name="MASE_RS00140" fbc:label="G_MASE_RS00140"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18420" fbc:name="MASE_RS18420" fbc:label="G_MASE_RS18420"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18410" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18410" fbc:name="MASE_RS18410" fbc:label="G_MASE_RS18410"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18035" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18035" fbc:name="MASE_RS18035" fbc:label="G_MASE_RS18035"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07605" fbc:name="MASE_RS07605" fbc:label="G_MASE_RS07605"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07615" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07615" fbc:name="MASE_RS07615" fbc:label="G_MASE_RS07615"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00905" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00905" fbc:name="MASE_RS00905" fbc:label="G_MASE_RS00905"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07945" fbc:name="MASE_RS07945" fbc:label="G_MASE_RS07945"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10130" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10130" fbc:name="MASE_RS10130" fbc:label="G_MASE_RS10130"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15065" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15065" fbc:name="MASE_RS15065" fbc:label="G_MASE_RS15065"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17185" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17185" fbc:name="MASE_RS17185" fbc:label="G_MASE_RS17185"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06485" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06485" fbc:name="MASE_RS06485" fbc:label="G_MASE_RS06485"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16280" fbc:name="MASE_RS16280" fbc:label="G_MASE_RS16280"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08980" fbc:name="MASE_RS08980" fbc:label="G_MASE_RS08980"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02920" fbc:name="MASE_RS02920" fbc:label="G_MASE_RS02920"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09350" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09350" fbc:name="MASE_RS09350" fbc:label="G_MASE_RS09350"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04465" fbc:name="MASE_RS04465" fbc:label="G_MASE_RS04465"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00005" fbc:name="MASE_RS00005" fbc:label="G_MASE_RS00005"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06490" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06490" fbc:name="MASE_RS06490" fbc:label="G_MASE_RS06490"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08640" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08640" fbc:name="MASE_RS08640" fbc:label="G_MASE_RS08640"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18780" fbc:name="MASE_RS18780" fbc:label="G_MASE_RS18780"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12175" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12175" fbc:name="MASE_RS12175" fbc:label="G_MASE_RS12175"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07730" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07730" fbc:name="MASE_RS07730" fbc:label="G_MASE_RS07730"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00020" fbc:name="MASE_RS00020" fbc:label="G_MASE_RS00020"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00010" fbc:name="MASE_RS00010" fbc:label="G_MASE_RS00010"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07790" fbc:name="MASE_RS07790" fbc:label="G_MASE_RS07790"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15700" fbc:name="MASE_RS15700" fbc:label="G_MASE_RS15700"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01505" fbc:name="MASE_RS01505" fbc:label="G_MASE_RS01505"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01495" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01495" fbc:name="MASE_RS01495" fbc:label="G_MASE_RS01495"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02405" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02405" fbc:name="MASE_RS02405" fbc:label="G_MASE_RS02405"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04145" fbc:name="MASE_RS04145" fbc:label="G_MASE_RS04145"/>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04050" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04050" fbc:name="MASE_RS04050" fbc:label="G_MASE_RS04050">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04050">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948483.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04060" fbc:name="MASE_RS04060" fbc:label="G_MASE_RS04060">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04060">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948484.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13310" fbc:name="MASE_RS13310" fbc:label="G_MASE_RS13310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950265.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14005" fbc:name="MASE_RS14005" fbc:label="G_MASE_RS14005">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950401.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04205" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04205" fbc:name="MASE_RS04205" fbc:label="G_MASE_RS04205">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04205">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948514.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04190" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04190" fbc:name="MASE_RS04190" fbc:label="G_MASE_RS04190">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04190">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948511.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04195" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04195" fbc:name="MASE_RS04195" fbc:label="G_MASE_RS04195">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04195">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948512.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04200" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04200" fbc:name="MASE_RS04200" fbc:label="G_MASE_RS04200">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04200">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948513.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15910" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15910" fbc:name="MASE_RS15910" fbc:label="G_MASE_RS15910">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15910">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950741.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14425" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14425" fbc:name="MASE_RS14425" fbc:label="G_MASE_RS14425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950475.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09580" fbc:name="MASE_RS09580" fbc:label="G_MASE_RS09580">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09580">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949540.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06570" fbc:name="MASE_RS06570" fbc:label="G_MASE_RS06570">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06570">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948964.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04150" fbc:name="MASE_RS04150" fbc:label="G_MASE_RS04150">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04150">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948503.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18995" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18995" fbc:name="MASE_RS18995" fbc:label="G_MASE_RS18995">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18995">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951323.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03315" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03315" fbc:name="MASE_RS03315" fbc:label="G_MASE_RS03315">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03315">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948339.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03205" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03205" fbc:name="MASE_RS03205" fbc:label="G_MASE_RS03205">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03205">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948318.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14140" fbc:name="MASE_RS14140" fbc:label="G_MASE_RS14140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950428.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02860" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02860" fbc:name="MASE_RS02860" fbc:label="G_MASE_RS02860">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02860">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948253.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18830" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18830" fbc:name="MASE_RS18830" fbc:label="G_MASE_RS18830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951290.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01375" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01375" fbc:name="MASE_RS01375" fbc:label="G_MASE_RS01375">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01375">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947970.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14380" fbc:name="MASE_RS14380" fbc:label="G_MASE_RS14380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950466.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08200" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08200" fbc:name="MASE_RS08200" fbc:label="G_MASE_RS08200">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08200">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949268.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08205" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08205" fbc:name="MASE_RS08205" fbc:label="G_MASE_RS08205">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08205">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949269.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09730" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09730" fbc:name="MASE_RS09730" fbc:label="G_MASE_RS09730">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09730">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949571.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02060" fbc:name="MASE_RS02060" fbc:label="G_MASE_RS02060">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02060">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948098.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19540" fbc:name="MASE_RS19540" fbc:label="G_MASE_RS19540">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19540">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951418.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11245" fbc:name="MASE_RS11245" fbc:label="G_MASE_RS11245">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11245">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949867.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13010" fbc:name="MASE_RS13010" fbc:label="G_MASE_RS13010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950205.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14325" fbc:name="MASE_RS14325" fbc:label="G_MASE_RS14325">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14325">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950455.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16905" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16905" fbc:name="MASE_RS16905" fbc:label="G_MASE_RS16905">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16905">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950918.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03455" fbc:name="MASE_RS03455" fbc:label="G_MASE_RS03455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948365.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10265" fbc:name="MASE_RS10265" fbc:label="G_MASE_RS10265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949673.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06735" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06735" fbc:name="MASE_RS06735" fbc:label="G_MASE_RS06735">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06735">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948995.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13815" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13815" fbc:name="MASE_RS13815" fbc:label="G_MASE_RS13815">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13815">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950364.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03790" fbc:name="MASE_RS03790" fbc:label="G_MASE_RS03790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948433.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19415" fbc:name="MASE_RS19415" fbc:label="G_MASE_RS19415">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19415">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948433.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12415" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12415" fbc:name="MASE_RS12415" fbc:label="G_MASE_RS12415">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12415">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950093.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00760" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00760" fbc:name="MASE_RS00760" fbc:label="G_MASE_RS00760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947851.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02620" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02620" fbc:name="MASE_RS02620" fbc:label="G_MASE_RS02620">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02620">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948206.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06680" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06680" fbc:name="MASE_RS06680" fbc:label="G_MASE_RS06680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948985.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17700" fbc:name="MASE_RS17700" fbc:label="G_MASE_RS17700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951072.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10765" fbc:name="MASE_RS10765" fbc:label="G_MASE_RS10765">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10765">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949770.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11125" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11125" fbc:name="MASE_RS11125" fbc:label="G_MASE_RS11125">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11125">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949843.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07230" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07230" fbc:name="MASE_RS07230" fbc:label="G_MASE_RS07230">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07230">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949087.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07600" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07600" fbc:name="MASE_RS07600" fbc:label="G_MASE_RS07600">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07600">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949156.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06240" fbc:name="MASE_RS06240" fbc:label="G_MASE_RS06240">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06240">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948904.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01640" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01640" fbc:name="MASE_RS01640" fbc:label="G_MASE_RS01640">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01640">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948019.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18840" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18840" fbc:name="MASE_RS18840" fbc:label="G_MASE_RS18840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951292.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06650" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06650" fbc:name="MASE_RS06650" fbc:label="G_MASE_RS06650">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06650">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948979.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06655" fbc:name="MASE_RS06655" fbc:label="G_MASE_RS06655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948980.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13005" fbc:name="MASE_RS13005" fbc:label="G_MASE_RS13005">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950204.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06455" fbc:name="MASE_RS06455" fbc:label="G_MASE_RS06455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948942.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12440" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12440" fbc:name="MASE_RS12440" fbc:label="G_MASE_RS12440">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12440">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950098.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05115" fbc:name="MASE_RS05115" fbc:label="G_MASE_RS05115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948687.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11930" fbc:name="MASE_RS11930" fbc:label="G_MASE_RS11930">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11930">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950001.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14780" fbc:name="MASE_RS14780" fbc:label="G_MASE_RS14780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950545.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11660" fbc:name="MASE_RS11660" fbc:label="G_MASE_RS11660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949949.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12395" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12395" fbc:name="MASE_RS12395" fbc:label="G_MASE_RS12395">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12395">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950090.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10145" fbc:name="MASE_RS10145" fbc:label="G_MASE_RS10145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949649.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10140" fbc:name="MASE_RS10140" fbc:label="G_MASE_RS10140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949648.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02175" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02175" fbc:name="MASE_RS02175" fbc:label="G_MASE_RS02175">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02175">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948120.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16585" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16585" fbc:name="MASE_RS16585" fbc:label="G_MASE_RS16585">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16585">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950866.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08735" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08735" fbc:name="MASE_RS08735" fbc:label="G_MASE_RS08735">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08735">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949373.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14775" fbc:name="MASE_RS14775" fbc:label="G_MASE_RS14775">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14775">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950544.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15145" fbc:name="MASE_RS15145" fbc:label="G_MASE_RS15145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950616.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09960" fbc:name="MASE_RS09960" fbc:label="G_MASE_RS09960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693498.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14770" fbc:name="MASE_RS14770" fbc:label="G_MASE_RS14770">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14770">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950543.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07555" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07555" fbc:name="MASE_RS07555" fbc:label="G_MASE_RS07555">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07555">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949147.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08635" fbc:name="MASE_RS08635" fbc:label="G_MASE_RS08635">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08635">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_231513069.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07620" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07620" fbc:name="MASE_RS07620" fbc:label="G_MASE_RS07620">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07620">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949160.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12400" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12400" fbc:name="MASE_RS12400" fbc:label="G_MASE_RS12400">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12400">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950091.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17020" fbc:name="MASE_RS17020" fbc:label="G_MASE_RS17020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950941.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11790" fbc:name="MASE_RS11790" fbc:label="G_MASE_RS11790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949973.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16335" fbc:name="MASE_RS16335" fbc:label="G_MASE_RS16335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950825.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01590" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01590" fbc:name="MASE_RS01590" fbc:label="G_MASE_RS01590">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01590">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948009.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02965" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02965" fbc:name="MASE_RS02965" fbc:label="G_MASE_RS02965">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02965">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948274.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12265" fbc:name="MASE_RS12265" fbc:label="G_MASE_RS12265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950064.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10080" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10080" fbc:name="MASE_RS10080" fbc:label="G_MASE_RS10080">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10080">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949636.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11170" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11170" fbc:name="MASE_RS11170" fbc:label="G_MASE_RS11170">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11170">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949852.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14235" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14235" fbc:name="MASE_RS14235" fbc:label="G_MASE_RS14235">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14235">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950446.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10470" fbc:name="MASE_RS10470" fbc:label="G_MASE_RS10470">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10470">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949715.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14285" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14285" fbc:name="MASE_RS14285" fbc:label="G_MASE_RS14285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950446.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09240" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09240" fbc:name="MASE_RS09240" fbc:label="G_MASE_RS09240">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09240">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949473.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14115" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14115" fbc:name="MASE_RS14115" fbc:label="G_MASE_RS14115">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14115">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950423.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14465" fbc:name="MASE_RS14465" fbc:label="G_MASE_RS14465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950483.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19160" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19160" fbc:name="MASE_RS19160" fbc:label="G_MASE_RS19160">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19160">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951356.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16450" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16450" fbc:name="MASE_RS16450" fbc:label="G_MASE_RS16450">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16450">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950845.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11465" fbc:name="MASE_RS11465" fbc:label="G_MASE_RS11465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949911.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01740" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01740" fbc:name="MASE_RS01740" fbc:label="G_MASE_RS01740">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01740">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948039.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03215" fbc:name="MASE_RS03215" fbc:label="G_MASE_RS03215">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03215">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948320.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09520" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09520" fbc:name="MASE_RS09520" fbc:label="G_MASE_RS09520">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09520">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949528.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14930" fbc:name="MASE_RS14930" fbc:label="G_MASE_RS14930">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14930">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950575.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16665" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16665" fbc:name="MASE_RS16665" fbc:label="G_MASE_RS16665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693580.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09020" fbc:name="MASE_RS09020" fbc:label="G_MASE_RS09020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949431.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01980" fbc:name="MASE_RS01980" fbc:label="G_MASE_RS01980">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01980">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948084.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01975" fbc:name="MASE_RS01975" fbc:label="G_MASE_RS01975">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01975">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948083.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17760" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17760" fbc:name="MASE_RS17760" fbc:label="G_MASE_RS17760">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17760">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951084.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14480" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14480" fbc:name="MASE_RS14480" fbc:label="G_MASE_RS14480">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14480">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950485.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06460" fbc:name="MASE_RS06460" fbc:label="G_MASE_RS06460">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06460">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948943.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01580" fbc:name="MASE_RS01580" fbc:label="G_MASE_RS01580">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01580">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948007.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13470" fbc:name="MASE_RS13470" fbc:label="G_MASE_RS13470">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13470">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950295.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07720" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07720" fbc:name="MASE_RS07720" fbc:label="G_MASE_RS07720">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07720">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949180.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18340" fbc:name="MASE_RS18340" fbc:label="G_MASE_RS18340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951199.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11285" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11285" fbc:name="MASE_RS11285" fbc:label="G_MASE_RS11285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949875.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16460" fbc:name="MASE_RS16460" fbc:label="G_MASE_RS16460">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16460">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950847.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00140" fbc:name="MASE_RS00140" fbc:label="G_MASE_RS00140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947735.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18420" fbc:name="MASE_RS18420" fbc:label="G_MASE_RS18420">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18420">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951213.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18410" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18410" fbc:name="MASE_RS18410" fbc:label="G_MASE_RS18410">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18410">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951211.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18035" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18035" fbc:name="MASE_RS18035" fbc:label="G_MASE_RS18035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951137.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07605" fbc:name="MASE_RS07605" fbc:label="G_MASE_RS07605">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07605">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949157.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07615" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07615" fbc:name="MASE_RS07615" fbc:label="G_MASE_RS07615">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07615">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949159.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00905" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00905" fbc:name="MASE_RS00905" fbc:label="G_MASE_RS00905">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00905">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947881.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07945" fbc:name="MASE_RS07945" fbc:label="G_MASE_RS07945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949219.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10130" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10130" fbc:name="MASE_RS10130" fbc:label="G_MASE_RS10130">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10130">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949646.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15065" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15065" fbc:name="MASE_RS15065" fbc:label="G_MASE_RS15065">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15065">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012519633.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17185" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17185" fbc:name="MASE_RS17185" fbc:label="G_MASE_RS17185">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17185">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950974.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06485" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06485" fbc:name="MASE_RS06485" fbc:label="G_MASE_RS06485">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06485">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948947.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16280" fbc:name="MASE_RS16280" fbc:label="G_MASE_RS16280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950815.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08980" fbc:name="MASE_RS08980" fbc:label="G_MASE_RS08980">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08980">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949423.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02920" fbc:name="MASE_RS02920" fbc:label="G_MASE_RS02920">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02920">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948266.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09350" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09350" fbc:name="MASE_RS09350" fbc:label="G_MASE_RS09350">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09350">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_051129052.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04465" fbc:name="MASE_RS04465" fbc:label="G_MASE_RS04465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948566.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00005" fbc:name="MASE_RS00005" fbc:label="G_MASE_RS00005">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039228897.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06490" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06490" fbc:name="MASE_RS06490" fbc:label="G_MASE_RS06490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948948.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08640" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08640" fbc:name="MASE_RS08640" fbc:label="G_MASE_RS08640">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08640">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949355.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18780" fbc:name="MASE_RS18780" fbc:label="G_MASE_RS18780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951281.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12175" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12175" fbc:name="MASE_RS12175" fbc:label="G_MASE_RS12175">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12175">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950050.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07730" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07730" fbc:name="MASE_RS07730" fbc:label="G_MASE_RS07730">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07730">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949182.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00020" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00020" fbc:name="MASE_RS00020" fbc:label="G_MASE_RS00020">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00020">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947711.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00010" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00010" fbc:name="MASE_RS00010" fbc:label="G_MASE_RS00010">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00010">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012516526.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07790" fbc:name="MASE_RS07790" fbc:label="G_MASE_RS07790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949190.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15700" fbc:name="MASE_RS15700" fbc:label="G_MASE_RS15700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_051129052.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01505" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01505" fbc:name="MASE_RS01505" fbc:label="G_MASE_RS01505">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01505">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947992.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01495" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01495" fbc:name="MASE_RS01495" fbc:label="G_MASE_RS01495">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01495">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947990.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02405" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02405" fbc:name="MASE_RS02405" fbc:label="G_MASE_RS02405">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02405">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948163.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04145" fbc:name="MASE_RS04145" fbc:label="G_MASE_RS04145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948502.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS19430" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19430" fbc:name="MASE_RS19430" fbc:label="G_MASE_RS19430"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03805" fbc:name="MASE_RS03805" fbc:label="G_MASE_RS03805"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06845" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06845" fbc:name="MASE_RS06845" fbc:label="G_MASE_RS06845"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06840" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06840" fbc:name="MASE_RS06840" fbc:label="G_MASE_RS06840"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08975" fbc:name="MASE_RS08975" fbc:label="G_MASE_RS08975"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17845" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17845" fbc:name="MASE_RS17845" fbc:label="G_MASE_RS17845"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01465" fbc:name="MASE_RS01465" fbc:label="G_MASE_RS01465"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02055" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02055" fbc:name="MASE_RS02055" fbc:label="G_MASE_RS02055"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02150" fbc:name="MASE_RS02150" fbc:label="G_MASE_RS02150"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18055" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18055" fbc:name="MASE_RS18055" fbc:label="G_MASE_RS18055"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09605" fbc:name="MASE_RS09605" fbc:label="G_MASE_RS09605"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00375" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00375" fbc:name="MASE_RS00375" fbc:label="G_MASE_RS00375"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11910" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11910" fbc:name="MASE_RS11910" fbc:label="G_MASE_RS11910"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14865" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14865" fbc:name="MASE_RS14865" fbc:label="G_MASE_RS14865"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13790" fbc:name="MASE_RS13790" fbc:label="G_MASE_RS13790"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09795" fbc:name="MASE_RS09795" fbc:label="G_MASE_RS09795"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00380" fbc:name="MASE_RS00380" fbc:label="G_MASE_RS00380"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14975" fbc:name="MASE_RS14975" fbc:label="G_MASE_RS14975"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03400" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03400" fbc:name="MASE_RS03400" fbc:label="G_MASE_RS03400"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06635" fbc:name="MASE_RS06635" fbc:label="G_MASE_RS06635"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18070" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18070" fbc:name="MASE_RS18070" fbc:label="G_MASE_RS18070"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19635" fbc:name="MASE_RS19635" fbc:label="G_MASE_RS19635"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04770" fbc:name="MASE_RS04770" fbc:label="G_MASE_RS04770"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10260" fbc:name="MASE_RS10260" fbc:label="G_MASE_RS10260"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06560" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06560" fbc:name="MASE_RS06560" fbc:label="G_MASE_RS06560"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10225" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10225" fbc:name="MASE_RS10225" fbc:label="G_MASE_RS10225"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05855" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05855" fbc:name="MASE_RS05855" fbc:label="G_MASE_RS05855"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02035" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02035" fbc:name="MASE_RS02035" fbc:label="G_MASE_RS02035"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07940" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07940" fbc:name="MASE_RS07940" fbc:label="G_MASE_RS07940"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07820" fbc:name="MASE_RS07820" fbc:label="G_MASE_RS07820"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08265" fbc:name="MASE_RS08265" fbc:label="G_MASE_RS08265"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14165" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14165" fbc:name="MASE_RS14165" fbc:label="G_MASE_RS14165"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01895" fbc:name="MASE_RS01895" fbc:label="G_MASE_RS01895"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08960" fbc:name="MASE_RS08960" fbc:label="G_MASE_RS08960"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07930" fbc:name="MASE_RS07930" fbc:label="G_MASE_RS07930"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13255" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13255" fbc:name="MASE_RS13255" fbc:label="G_MASE_RS13255"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09515" fbc:name="MASE_RS09515" fbc:label="G_MASE_RS09515"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01660" fbc:name="MASE_RS01660" fbc:label="G_MASE_RS01660"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10320" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10320" fbc:name="MASE_RS10320" fbc:label="G_MASE_RS10320"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07880" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07880" fbc:name="MASE_RS07880" fbc:label="G_MASE_RS07880"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09810" fbc:name="MASE_RS09810" fbc:label="G_MASE_RS09810"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09800" fbc:name="MASE_RS09800" fbc:label="G_MASE_RS09800"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09805" fbc:name="MASE_RS09805" fbc:label="G_MASE_RS09805"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18750" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18750" fbc:name="MASE_RS18750" fbc:label="G_MASE_RS18750"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17055" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17055" fbc:name="MASE_RS17055" fbc:label="G_MASE_RS17055"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00935" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00935" fbc:name="MASE_RS00935" fbc:label="G_MASE_RS00935"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16945" fbc:name="MASE_RS16945" fbc:label="G_MASE_RS16945"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15765" fbc:name="MASE_RS15765" fbc:label="G_MASE_RS15765"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18590" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18590" fbc:name="MASE_RS18590" fbc:label="G_MASE_RS18590"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18580" fbc:name="MASE_RS18580" fbc:label="G_MASE_RS18580"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18585" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18585" fbc:name="MASE_RS18585" fbc:label="G_MASE_RS18585"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06975" fbc:name="MASE_RS06975" fbc:label="G_MASE_RS06975"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11120" fbc:name="MASE_RS11120" fbc:label="G_MASE_RS11120"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11295" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11295" fbc:name="MASE_RS11295" fbc:label="G_MASE_RS11295"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08105" fbc:name="MASE_RS08105" fbc:label="G_MASE_RS08105"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12765" fbc:name="MASE_RS12765" fbc:label="G_MASE_RS12765"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11110" fbc:name="MASE_RS11110" fbc:label="G_MASE_RS11110"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04320" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04320" fbc:name="MASE_RS04320" fbc:label="G_MASE_RS04320"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06960" fbc:name="MASE_RS06960" fbc:label="G_MASE_RS06960"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16345" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16345" fbc:name="MASE_RS16345" fbc:label="G_MASE_RS16345"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03015" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03015" fbc:name="MASE_RS03015" fbc:label="G_MASE_RS03015"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06285" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06285" fbc:name="MASE_RS06285" fbc:label="G_MASE_RS06285"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05895" fbc:name="MASE_RS05895" fbc:label="G_MASE_RS05895"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19145" fbc:name="MASE_RS19145" fbc:label="G_MASE_RS19145"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03540" fbc:name="MASE_RS03540" fbc:label="G_MASE_RS03540"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04945" fbc:name="MASE_RS04945" fbc:label="G_MASE_RS04945"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18160" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18160" fbc:name="MASE_RS18160" fbc:label="G_MASE_RS18160"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18445" fbc:name="MASE_RS18445" fbc:label="G_MASE_RS18445"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04950" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04950" fbc:name="MASE_RS04950" fbc:label="G_MASE_RS04950"/>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03805" fbc:name="MASE_RS03805" fbc:label="G_MASE_RS03805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948436.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06845" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06845" fbc:name="MASE_RS06845" fbc:label="G_MASE_RS06845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949014.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06840" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06840" fbc:name="MASE_RS06840" fbc:label="G_MASE_RS06840">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06840">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949013.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08975" fbc:name="MASE_RS08975" fbc:label="G_MASE_RS08975">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08975">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949422.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17845" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17845" fbc:name="MASE_RS17845" fbc:label="G_MASE_RS17845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951101.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01465" fbc:name="MASE_RS01465" fbc:label="G_MASE_RS01465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947984.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02055" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02055" fbc:name="MASE_RS02055" fbc:label="G_MASE_RS02055">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02055">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948097.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02150" fbc:name="MASE_RS02150" fbc:label="G_MASE_RS02150">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02150">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948115.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18055" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18055" fbc:name="MASE_RS18055" fbc:label="G_MASE_RS18055">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18055">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951141.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09605" fbc:name="MASE_RS09605" fbc:label="G_MASE_RS09605">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09605">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949545.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00375" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00375" fbc:name="MASE_RS00375" fbc:label="G_MASE_RS00375">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00375">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947776.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11910" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11910" fbc:name="MASE_RS11910" fbc:label="G_MASE_RS11910">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11910">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949997.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14865" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14865" fbc:name="MASE_RS14865" fbc:label="G_MASE_RS14865">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14865">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950562.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13790" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13790" fbc:name="MASE_RS13790" fbc:label="G_MASE_RS13790">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13790">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950359.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09795" fbc:name="MASE_RS09795" fbc:label="G_MASE_RS09795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949584.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00380" fbc:name="MASE_RS00380" fbc:label="G_MASE_RS00380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947777.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14975" fbc:name="MASE_RS14975" fbc:label="G_MASE_RS14975">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14975">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950584.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03400" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03400" fbc:name="MASE_RS03400" fbc:label="G_MASE_RS03400">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03400">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948355.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06635" fbc:name="MASE_RS06635" fbc:label="G_MASE_RS06635">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06635">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948976.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18070" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18070" fbc:name="MASE_RS18070" fbc:label="G_MASE_RS18070">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18070">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951144.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19635" fbc:name="MASE_RS19635" fbc:label="G_MASE_RS19635">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19635">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951437.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04770" fbc:name="MASE_RS04770" fbc:label="G_MASE_RS04770">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04770">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948625.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10260" fbc:name="MASE_RS10260" fbc:label="G_MASE_RS10260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949672.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06560" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06560" fbc:name="MASE_RS06560" fbc:label="G_MASE_RS06560">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06560">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948962.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10225" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10225" fbc:name="MASE_RS10225" fbc:label="G_MASE_RS10225">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10225">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949665.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05855" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05855" fbc:name="MASE_RS05855" fbc:label="G_MASE_RS05855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948830.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02035" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02035" fbc:name="MASE_RS02035" fbc:label="G_MASE_RS02035">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02035">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012517074.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07940" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07940" fbc:name="MASE_RS07940" fbc:label="G_MASE_RS07940">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07940">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949218.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07820" fbc:name="MASE_RS07820" fbc:label="G_MASE_RS07820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949196.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08265" fbc:name="MASE_RS08265" fbc:label="G_MASE_RS08265">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08265">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949281.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14165" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14165" fbc:name="MASE_RS14165" fbc:label="G_MASE_RS14165">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14165">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950433.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01895" fbc:name="MASE_RS01895" fbc:label="G_MASE_RS01895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948069.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08960" fbc:name="MASE_RS08960" fbc:label="G_MASE_RS08960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693482.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07930" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07930" fbc:name="MASE_RS07930" fbc:label="G_MASE_RS07930">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07930">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949216.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13255" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13255" fbc:name="MASE_RS13255" fbc:label="G_MASE_RS13255">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13255">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950254.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09515" fbc:name="MASE_RS09515" fbc:label="G_MASE_RS09515">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09515">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949527.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01660" fbc:name="MASE_RS01660" fbc:label="G_MASE_RS01660">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01660">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948023.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10320" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10320" fbc:name="MASE_RS10320" fbc:label="G_MASE_RS10320">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10320">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232362753.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07880" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07880" fbc:name="MASE_RS07880" fbc:label="G_MASE_RS07880">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07880">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949208.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09810" fbc:name="MASE_RS09810" fbc:label="G_MASE_RS09810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949587.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09800" fbc:name="MASE_RS09800" fbc:label="G_MASE_RS09800">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09800">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949585.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09805" fbc:name="MASE_RS09805" fbc:label="G_MASE_RS09805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949586.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18750" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18750" fbc:name="MASE_RS18750" fbc:label="G_MASE_RS18750">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18750">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951275.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17055" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17055" fbc:name="MASE_RS17055" fbc:label="G_MASE_RS17055">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17055">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950948.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00935" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00935" fbc:name="MASE_RS00935" fbc:label="G_MASE_RS00935">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00935">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947887.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16945" fbc:name="MASE_RS16945" fbc:label="G_MASE_RS16945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950926.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15765" fbc:name="MASE_RS15765" fbc:label="G_MASE_RS15765">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15765">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950712.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18590" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18590" fbc:name="MASE_RS18590" fbc:label="G_MASE_RS18590">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18590">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951246.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18580" fbc:name="MASE_RS18580" fbc:label="G_MASE_RS18580">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18580">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951244.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18585" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18585" fbc:name="MASE_RS18585" fbc:label="G_MASE_RS18585">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18585">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951245.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06975" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06975" fbc:name="MASE_RS06975" fbc:label="G_MASE_RS06975">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06975">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949038.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11120" fbc:name="MASE_RS11120" fbc:label="G_MASE_RS11120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949842.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11295" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11295" fbc:name="MASE_RS11295" fbc:label="G_MASE_RS11295">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11295">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949877.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08105" fbc:name="MASE_RS08105" fbc:label="G_MASE_RS08105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949251.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12765" fbc:name="MASE_RS12765" fbc:label="G_MASE_RS12765">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12765">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950158.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11110" fbc:name="MASE_RS11110" fbc:label="G_MASE_RS11110">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11110">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949840.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04320" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04320" fbc:name="MASE_RS04320" fbc:label="G_MASE_RS04320">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04320">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948537.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06960" fbc:name="MASE_RS06960" fbc:label="G_MASE_RS06960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949035.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16345" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16345" fbc:name="MASE_RS16345" fbc:label="G_MASE_RS16345">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16345">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950827.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03015" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03015" fbc:name="MASE_RS03015" fbc:label="G_MASE_RS03015">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03015">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948284.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06285" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06285" fbc:name="MASE_RS06285" fbc:label="G_MASE_RS06285">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06285">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948913.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05895" fbc:name="MASE_RS05895" fbc:label="G_MASE_RS05895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948838.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19145" fbc:name="MASE_RS19145" fbc:label="G_MASE_RS19145">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19145">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951353.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03540" fbc:name="MASE_RS03540" fbc:label="G_MASE_RS03540">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03540">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948383.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04945" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04945" fbc:name="MASE_RS04945" fbc:label="G_MASE_RS04945">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04945">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948657.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18160" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18160" fbc:name="MASE_RS18160" fbc:label="G_MASE_RS18160">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18160">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232362782.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18445" fbc:name="MASE_RS18445" fbc:label="G_MASE_RS18445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951218.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04950" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04950" fbc:name="MASE_RS04950" fbc:label="G_MASE_RS04950">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04950">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948658.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS12365" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12365" fbc:name="MASE_RS12365" fbc:label="G_MASE_RS12365"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14895" fbc:name="MASE_RS14895" fbc:label="G_MASE_RS14895"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13925" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13925" fbc:name="MASE_RS13925" fbc:label="G_MASE_RS13925"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19525" fbc:name="MASE_RS19525" fbc:label="G_MASE_RS19525"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00890" fbc:name="MASE_RS00890" fbc:label="G_MASE_RS00890"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04510" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04510" fbc:name="MASE_RS04510" fbc:label="G_MASE_RS04510"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18980" fbc:name="MASE_RS18980" fbc:label="G_MASE_RS18980"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13795" fbc:name="MASE_RS13795" fbc:label="G_MASE_RS13795"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13800" fbc:name="MASE_RS13800" fbc:label="G_MASE_RS13800"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01460" fbc:name="MASE_RS01460" fbc:label="G_MASE_RS01460"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11160" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11160" fbc:name="MASE_RS11160" fbc:label="G_MASE_RS11160"/>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14895" fbc:name="MASE_RS14895" fbc:label="G_MASE_RS14895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950568.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13925" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13925" fbc:name="MASE_RS13925" fbc:label="G_MASE_RS13925">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13925">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950386.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19525" fbc:name="MASE_RS19525" fbc:label="G_MASE_RS19525">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19525">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951415.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00890" fbc:name="MASE_RS00890" fbc:label="G_MASE_RS00890">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00890">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947878.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04510" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04510" fbc:name="MASE_RS04510" fbc:label="G_MASE_RS04510">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04510">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948575.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18980" fbc:name="MASE_RS18980" fbc:label="G_MASE_RS18980">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18980">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951320.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13795" fbc:name="MASE_RS13795" fbc:label="G_MASE_RS13795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950360.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13800" fbc:name="MASE_RS13800" fbc:label="G_MASE_RS13800">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13800">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950361.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01460" fbc:name="MASE_RS01460" fbc:label="G_MASE_RS01460">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01460">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947983.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11160" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11160" fbc:name="MASE_RS11160" fbc:label="G_MASE_RS11160">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11160">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949850.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS14470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14470" fbc:name="MASE_RS14470" fbc:label="G_MASE_RS14470"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17340" fbc:name="MASE_RS17340" fbc:label="G_MASE_RS17340"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11390" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11390" fbc:name="MASE_RS11390" fbc:label="G_MASE_RS11390"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00710" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00710" fbc:name="MASE_RS00710" fbc:label="G_MASE_RS00710"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03310" fbc:name="MASE_RS03310" fbc:label="G_MASE_RS03310"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06095" fbc:name="MASE_RS06095" fbc:label="G_MASE_RS06095"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05445" fbc:name="MASE_RS05445" fbc:label="G_MASE_RS05445"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02755" fbc:name="MASE_RS02755" fbc:label="G_MASE_RS02755"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03085" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03085" fbc:name="MASE_RS03085" fbc:label="G_MASE_RS03085"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03110" fbc:name="MASE_RS03110" fbc:label="G_MASE_RS03110"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01385" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01385" fbc:name="MASE_RS01385" fbc:label="G_MASE_RS01385"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18540" fbc:name="MASE_RS18540" fbc:label="G_MASE_RS18540"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00320" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00320" fbc:name="MASE_RS00320" fbc:label="G_MASE_RS00320"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06260" fbc:name="MASE_RS06260" fbc:label="G_MASE_RS06260"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08045" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08045" fbc:name="MASE_RS08045" fbc:label="G_MASE_RS08045"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14135" fbc:name="MASE_RS14135" fbc:label="G_MASE_RS14135"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15535" fbc:name="MASE_RS15535" fbc:label="G_MASE_RS15535"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15380" fbc:name="MASE_RS15380" fbc:label="G_MASE_RS15380"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15860" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15860" fbc:name="MASE_RS15860" fbc:label="G_MASE_RS15860"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13970" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13970" fbc:name="MASE_RS13970" fbc:label="G_MASE_RS13970"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12375" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12375" fbc:name="MASE_RS12375" fbc:label="G_MASE_RS12375"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01275" fbc:name="MASE_RS01275" fbc:label="G_MASE_RS01275"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16135" fbc:name="MASE_RS16135" fbc:label="G_MASE_RS16135"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11560" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11560" fbc:name="MASE_RS11560" fbc:label="G_MASE_RS11560"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01800" fbc:name="MASE_RS01800" fbc:label="G_MASE_RS01800"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17330" fbc:name="MASE_RS17330" fbc:label="G_MASE_RS17330"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17650" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17650" fbc:name="MASE_RS17650" fbc:label="G_MASE_RS17650"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07280" fbc:name="MASE_RS07280" fbc:label="G_MASE_RS07280"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02370" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02370" fbc:name="MASE_RS02370" fbc:label="G_MASE_RS02370"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07785" fbc:name="MASE_RS07785" fbc:label="G_MASE_RS07785"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13870" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13870" fbc:name="MASE_RS13870" fbc:label="G_MASE_RS13870"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14900" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14900" fbc:name="MASE_RS14900" fbc:label="G_MASE_RS14900"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05120" fbc:name="MASE_RS05120" fbc:label="G_MASE_RS05120"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08780" fbc:name="MASE_RS08780" fbc:label="G_MASE_RS08780"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15610" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15610" fbc:name="MASE_RS15610" fbc:label="G_MASE_RS15610"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04405" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04405" fbc:name="MASE_RS04405" fbc:label="G_MASE_RS04405"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07135" fbc:name="MASE_RS07135" fbc:label="G_MASE_RS07135"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12360" fbc:name="MASE_RS12360" fbc:label="G_MASE_RS12360"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06275" fbc:name="MASE_RS06275" fbc:label="G_MASE_RS06275"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14805" fbc:name="MASE_RS14805" fbc:label="G_MASE_RS14805"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04940" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04940" fbc:name="MASE_RS04940" fbc:label="G_MASE_RS04940"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14155" fbc:name="MASE_RS14155" fbc:label="G_MASE_RS14155"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07130" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07130" fbc:name="MASE_RS07130" fbc:label="G_MASE_RS07130"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00885" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00885" fbc:name="MASE_RS00885" fbc:label="G_MASE_RS00885"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19165" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19165" fbc:name="MASE_RS19165" fbc:label="G_MASE_RS19165"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01530" fbc:name="MASE_RS01530" fbc:label="G_MASE_RS01530"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01735" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01735" fbc:name="MASE_RS01735" fbc:label="G_MASE_RS01735"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11700" fbc:name="MASE_RS11700" fbc:label="G_MASE_RS11700"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08135" fbc:name="MASE_RS08135" fbc:label="G_MASE_RS08135"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17525" fbc:name="MASE_RS17525" fbc:label="G_MASE_RS17525"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02915" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02915" fbc:name="MASE_RS02915" fbc:label="G_MASE_RS02915"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12465" fbc:name="MASE_RS12465" fbc:label="G_MASE_RS12465"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17520" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17520" fbc:name="MASE_RS17520" fbc:label="G_MASE_RS17520"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16800" fbc:name="MASE_RS16800" fbc:label="G_MASE_RS16800"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19785" fbc:name="MASE_RS19785" fbc:label="G_MASE_RS19785"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02960" fbc:name="MASE_RS02960" fbc:label="G_MASE_RS02960"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00895" fbc:name="MASE_RS00895" fbc:label="G_MASE_RS00895"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02065" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02065" fbc:name="MASE_RS02065" fbc:label="G_MASE_RS02065"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08585" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08585" fbc:name="MASE_RS08585" fbc:label="G_MASE_RS08585"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09085" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09085" fbc:name="MASE_RS09085" fbc:label="G_MASE_RS09085"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12535" fbc:name="MASE_RS12535" fbc:label="G_MASE_RS12535"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04450" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04450" fbc:name="MASE_RS04450" fbc:label="G_MASE_RS04450"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13635" fbc:name="MASE_RS13635" fbc:label="G_MASE_RS13635"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14600" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14600" fbc:name="MASE_RS14600" fbc:label="G_MASE_RS14600"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07220" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07220" fbc:name="MASE_RS07220" fbc:label="G_MASE_RS07220"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07180" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07180" fbc:name="MASE_RS07180" fbc:label="G_MASE_RS07180"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11855" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11855" fbc:name="MASE_RS11855" fbc:label="G_MASE_RS11855"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13395" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13395" fbc:name="MASE_RS13395" fbc:label="G_MASE_RS13395"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06250" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06250" fbc:name="MASE_RS06250" fbc:label="G_MASE_RS06250"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17755" fbc:name="MASE_RS17755" fbc:label="G_MASE_RS17755"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08700" fbc:name="MASE_RS08700" fbc:label="G_MASE_RS08700"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08095" fbc:name="MASE_RS08095" fbc:label="G_MASE_RS08095"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15625" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15625" fbc:name="MASE_RS15625" fbc:label="G_MASE_RS15625"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11480" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11480" fbc:name="MASE_RS11480" fbc:label="G_MASE_RS11480"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09275" fbc:name="MASE_RS09275" fbc:label="G_MASE_RS09275"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17625" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17625" fbc:name="MASE_RS17625" fbc:label="G_MASE_RS17625"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07270" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07270" fbc:name="MASE_RS07270" fbc:label="G_MASE_RS07270"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04380" fbc:name="MASE_RS04380" fbc:label="G_MASE_RS04380"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10210" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10210" fbc:name="MASE_RS10210" fbc:label="G_MASE_RS10210"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01815" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01815" fbc:name="MASE_RS01815" fbc:label="G_MASE_RS01815"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12655" fbc:name="MASE_RS12655" fbc:label="G_MASE_RS12655"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11530" fbc:name="MASE_RS11530" fbc:label="G_MASE_RS11530"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17335" fbc:name="MASE_RS17335" fbc:label="G_MASE_RS17335"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15795" fbc:name="MASE_RS15795" fbc:label="G_MASE_RS15795"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15800" fbc:name="MASE_RS15800" fbc:label="G_MASE_RS15800"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18740" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18740" fbc:name="MASE_RS18740" fbc:label="G_MASE_RS18740"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09070" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09070" fbc:name="MASE_RS09070" fbc:label="G_MASE_RS09070"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16785" fbc:name="MASE_RS16785" fbc:label="G_MASE_RS16785"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14980" fbc:name="MASE_RS14980" fbc:label="G_MASE_RS14980"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10625" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10625" fbc:name="MASE_RS10625" fbc:label="G_MASE_RS10625"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10620" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10620" fbc:name="MASE_RS10620" fbc:label="G_MASE_RS10620"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17655" fbc:name="MASE_RS17655" fbc:label="G_MASE_RS17655"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00480" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00480" fbc:name="MASE_RS00480" fbc:label="G_MASE_RS00480"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05140" fbc:name="MASE_RS05140" fbc:label="G_MASE_RS05140"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17775" fbc:name="MASE_RS17775" fbc:label="G_MASE_RS17775"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11490" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11490" fbc:name="MASE_RS11490" fbc:label="G_MASE_RS11490"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18275" fbc:name="MASE_RS18275" fbc:label="G_MASE_RS18275"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01135" fbc:name="MASE_RS01135" fbc:label="G_MASE_RS01135"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11175" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11175" fbc:name="MASE_RS11175" fbc:label="G_MASE_RS11175"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00315" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00315" fbc:name="MASE_RS00315" fbc:label="G_MASE_RS00315"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06645" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06645" fbc:name="MASE_RS06645" fbc:label="G_MASE_RS06645"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS01805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01805" fbc:name="MASE_RS01805" fbc:label="G_MASE_RS01805"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10910" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10910" fbc:name="MASE_RS10910" fbc:label="G_MASE_RS10910"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10125" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10125" fbc:name="MASE_RS10125" fbc:label="G_MASE_RS10125"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10340" fbc:name="MASE_RS10340" fbc:label="G_MASE_RS10340"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08545" fbc:name="MASE_RS08545" fbc:label="G_MASE_RS08545"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12665" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12665" fbc:name="MASE_RS12665" fbc:label="G_MASE_RS12665"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07005" fbc:name="MASE_RS07005" fbc:label="G_MASE_RS07005"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02510" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02510" fbc:name="MASE_RS02510" fbc:label="G_MASE_RS02510"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13030" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13030" fbc:name="MASE_RS13030" fbc:label="G_MASE_RS13030"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11730" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11730" fbc:name="MASE_RS11730" fbc:label="G_MASE_RS11730"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05580" fbc:name="MASE_RS05580" fbc:label="G_MASE_RS05580"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13495" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13495" fbc:name="MASE_RS13495" fbc:label="G_MASE_RS13495"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19215" fbc:name="MASE_RS19215" fbc:label="G_MASE_RS19215"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12165" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12165" fbc:name="MASE_RS12165" fbc:label="G_MASE_RS12165"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10785" fbc:name="MASE_RS10785" fbc:label="G_MASE_RS10785"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00460" fbc:name="MASE_RS00460" fbc:label="G_MASE_RS00460"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10335" fbc:name="MASE_RS10335" fbc:label="G_MASE_RS10335"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00470" fbc:name="MASE_RS00470" fbc:label="G_MASE_RS00470"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19280" fbc:name="MASE_RS19280" fbc:label="G_MASE_RS19280"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02775" fbc:name="MASE_RS02775" fbc:label="G_MASE_RS02775"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18675" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18675" fbc:name="MASE_RS18675" fbc:label="G_MASE_RS18675"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18680" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18680" fbc:name="MASE_RS18680" fbc:label="G_MASE_RS18680"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18685" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18685" fbc:name="MASE_RS18685" fbc:label="G_MASE_RS18685"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18690" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18690" fbc:name="MASE_RS18690" fbc:label="G_MASE_RS18690"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16980" fbc:name="MASE_RS16980" fbc:label="G_MASE_RS16980"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16985" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16985" fbc:name="MASE_RS16985" fbc:label="G_MASE_RS16985"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18105" fbc:name="MASE_RS18105" fbc:label="G_MASE_RS18105"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18100" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18100" fbc:name="MASE_RS18100" fbc:label="G_MASE_RS18100"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09830" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09830" fbc:name="MASE_RS09830" fbc:label="G_MASE_RS09830"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09820" fbc:name="MASE_RS09820" fbc:label="G_MASE_RS09820"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09835" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09835" fbc:name="MASE_RS09835" fbc:label="G_MASE_RS09835"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09825" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09825" fbc:name="MASE_RS09825" fbc:label="G_MASE_RS09825"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09850" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09850" fbc:name="MASE_RS09850" fbc:label="G_MASE_RS09850"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02575" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02575" fbc:name="MASE_RS02575" fbc:label="G_MASE_RS02575"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02845" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02845" fbc:name="MASE_RS02845" fbc:label="G_MASE_RS02845"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15550" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15550" fbc:name="MASE_RS15550" fbc:label="G_MASE_RS15550"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19695" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19695" fbc:name="MASE_RS19695" fbc:label="G_MASE_RS19695"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19705" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19705" fbc:name="MASE_RS19705" fbc:label="G_MASE_RS19705"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19720" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19720" fbc:name="MASE_RS19720" fbc:label="G_MASE_RS19720"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19690" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19690" fbc:name="MASE_RS19690" fbc:label="G_MASE_RS19690"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19710" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19710" fbc:name="MASE_RS19710" fbc:label="G_MASE_RS19710"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19730" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19730" fbc:name="MASE_RS19730" fbc:label="G_MASE_RS19730"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19700" fbc:name="MASE_RS19700" fbc:label="G_MASE_RS19700"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19715" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19715" fbc:name="MASE_RS19715" fbc:label="G_MASE_RS19715"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19725" fbc:name="MASE_RS19725" fbc:label="G_MASE_RS19725"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03270" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03270" fbc:name="MASE_RS03270" fbc:label="G_MASE_RS03270"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03275" fbc:name="MASE_RS03275" fbc:label="G_MASE_RS03275"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19300" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19300" fbc:name="MASE_RS19300" fbc:label="G_MASE_RS19300"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19310" fbc:name="MASE_RS19310" fbc:label="G_MASE_RS19310"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19315" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19315" fbc:name="MASE_RS19315" fbc:label="G_MASE_RS19315"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10775" fbc:name="MASE_RS10775" fbc:label="G_MASE_RS10775"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10795" fbc:name="MASE_RS10795" fbc:label="G_MASE_RS10795"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10325" fbc:name="MASE_RS10325" fbc:label="G_MASE_RS10325"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07810" fbc:name="MASE_RS07810" fbc:label="G_MASE_RS07810"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00295" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00295" fbc:name="MASE_RS00295" fbc:label="G_MASE_RS00295"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14630" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14630" fbc:name="MASE_RS14630" fbc:label="G_MASE_RS14630"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06255" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06255" fbc:name="MASE_RS06255" fbc:label="G_MASE_RS06255"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00795" fbc:name="MASE_RS00795" fbc:label="G_MASE_RS00795"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00455" fbc:name="MASE_RS00455" fbc:label="G_MASE_RS00455"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07140" fbc:name="MASE_RS07140" fbc:label="G_MASE_RS07140"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04330" fbc:name="MASE_RS04330" fbc:label="G_MASE_RS04330"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16100" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16100" fbc:name="MASE_RS16100" fbc:label="G_MASE_RS16100"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16105" fbc:name="MASE_RS16105" fbc:label="G_MASE_RS16105"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16090" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16090" fbc:name="MASE_RS16090" fbc:label="G_MASE_RS16090"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13875" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13875" fbc:name="MASE_RS13875" fbc:label="G_MASE_RS13875"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12810" fbc:name="MASE_RS12810" fbc:label="G_MASE_RS12810"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11100" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11100" fbc:name="MASE_RS11100" fbc:label="G_MASE_RS11100"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14955" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14955" fbc:name="MASE_RS14955" fbc:label="G_MASE_RS14955"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS03105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03105" fbc:name="MASE_RS03105" fbc:label="G_MASE_RS03105"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08595" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08595" fbc:name="MASE_RS08595" fbc:label="G_MASE_RS08595"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08425" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08425" fbc:name="MASE_RS08425" fbc:label="G_MASE_RS08425"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05150" fbc:name="MASE_RS05150" fbc:label="G_MASE_RS05150"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05650" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05650" fbc:name="MASE_RS05650" fbc:label="G_MASE_RS05650"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05655" fbc:name="MASE_RS05655" fbc:label="G_MASE_RS05655"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09380" fbc:name="MASE_RS09380" fbc:label="G_MASE_RS09380"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10880" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10880" fbc:name="MASE_RS10880" fbc:label="G_MASE_RS10880"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS00820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00820" fbc:name="MASE_RS00820" fbc:label="G_MASE_RS00820"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14625" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14625" fbc:name="MASE_RS14625" fbc:label="G_MASE_RS14625"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06245" fbc:name="MASE_RS06245" fbc:label="G_MASE_RS06245"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16085" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16085" fbc:name="MASE_RS16085" fbc:label="G_MASE_RS16085"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18670" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18670" fbc:name="MASE_RS18670" fbc:label="G_MASE_RS18670"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19275" fbc:name="MASE_RS19275" fbc:label="G_MASE_RS19275"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16095" fbc:name="MASE_RS16095" fbc:label="G_MASE_RS16095"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS05420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05420" fbc:name="MASE_RS05420" fbc:label="G_MASE_RS05420"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS02325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02325" fbc:name="MASE_RS02325" fbc:label="G_MASE_RS02325"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12850" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12850" fbc:name="MASE_RS12850" fbc:label="G_MASE_RS12850"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12870" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12870" fbc:name="MASE_RS12870" fbc:label="G_MASE_RS12870"/>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17340" fbc:name="MASE_RS17340" fbc:label="G_MASE_RS17340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951003.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11390" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11390" fbc:name="MASE_RS11390" fbc:label="G_MASE_RS11390">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11390">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949896.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00710" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00710" fbc:name="MASE_RS00710" fbc:label="G_MASE_RS00710">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00710">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947842.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03310" fbc:name="MASE_RS03310" fbc:label="G_MASE_RS03310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948338.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06095" fbc:name="MASE_RS06095" fbc:label="G_MASE_RS06095">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06095">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948875.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05445" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05445" fbc:name="MASE_RS05445" fbc:label="G_MASE_RS05445">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05445">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948749.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02755" fbc:name="MASE_RS02755" fbc:label="G_MASE_RS02755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948233.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03085" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03085" fbc:name="MASE_RS03085" fbc:label="G_MASE_RS03085">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03085">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948296.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03110" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03110" fbc:name="MASE_RS03110" fbc:label="G_MASE_RS03110">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03110">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948301.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01385" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01385" fbc:name="MASE_RS01385" fbc:label="G_MASE_RS01385">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01385">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947972.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18540" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18540" fbc:name="MASE_RS18540" fbc:label="G_MASE_RS18540">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18540">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951237.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00320" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00320" fbc:name="MASE_RS00320" fbc:label="G_MASE_RS00320">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00320">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947766.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06260" fbc:name="MASE_RS06260" fbc:label="G_MASE_RS06260">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06260">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948908.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08045" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08045" fbc:name="MASE_RS08045" fbc:label="G_MASE_RS08045">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08045">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949239.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14135" fbc:name="MASE_RS14135" fbc:label="G_MASE_RS14135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950427.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15535" fbc:name="MASE_RS15535" fbc:label="G_MASE_RS15535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950690.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15380" fbc:name="MASE_RS15380" fbc:label="G_MASE_RS15380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950659.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15860" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15860" fbc:name="MASE_RS15860" fbc:label="G_MASE_RS15860">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15860">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950731.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13970" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13970" fbc:name="MASE_RS13970" fbc:label="G_MASE_RS13970">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13970">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950394.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12375" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12375" fbc:name="MASE_RS12375" fbc:label="G_MASE_RS12375">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12375">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950086.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01275" fbc:name="MASE_RS01275" fbc:label="G_MASE_RS01275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947954.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16135" fbc:name="MASE_RS16135" fbc:label="G_MASE_RS16135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_080589189.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11560" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11560" fbc:name="MASE_RS11560" fbc:label="G_MASE_RS11560">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11560">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949929.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01800" fbc:name="MASE_RS01800" fbc:label="G_MASE_RS01800">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01800">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948050.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17330" fbc:name="MASE_RS17330" fbc:label="G_MASE_RS17330">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17330">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951001.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17650" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17650" fbc:name="MASE_RS17650" fbc:label="G_MASE_RS17650">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17650">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951062.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07280" fbc:name="MASE_RS07280" fbc:label="G_MASE_RS07280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949096.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02370" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02370" fbc:name="MASE_RS02370" fbc:label="G_MASE_RS02370">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02370">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693359.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07785" fbc:name="MASE_RS07785" fbc:label="G_MASE_RS07785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949189.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13870" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13870" fbc:name="MASE_RS13870" fbc:label="G_MASE_RS13870">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13870">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950375.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14900" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14900" fbc:name="MASE_RS14900" fbc:label="G_MASE_RS14900">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14900">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950569.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05120" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05120" fbc:name="MASE_RS05120" fbc:label="G_MASE_RS05120">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05120">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948688.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08780" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08780" fbc:name="MASE_RS08780" fbc:label="G_MASE_RS08780">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08780">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949382.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15610" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15610" fbc:name="MASE_RS15610" fbc:label="G_MASE_RS15610">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15610">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950705.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04405" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04405" fbc:name="MASE_RS04405" fbc:label="G_MASE_RS04405">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04405">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948554.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07135" fbc:name="MASE_RS07135" fbc:label="G_MASE_RS07135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949068.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12360" fbc:name="MASE_RS12360" fbc:label="G_MASE_RS12360">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12360">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950084.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06275" fbc:name="MASE_RS06275" fbc:label="G_MASE_RS06275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014976065.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14805" fbc:name="MASE_RS14805" fbc:label="G_MASE_RS14805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950550.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04940" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04940" fbc:name="MASE_RS04940" fbc:label="G_MASE_RS04940">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04940">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948656.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14155" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14155" fbc:name="MASE_RS14155" fbc:label="G_MASE_RS14155">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14155">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950431.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07130" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07130" fbc:name="MASE_RS07130" fbc:label="G_MASE_RS07130">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07130">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949067.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00885" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00885" fbc:name="MASE_RS00885" fbc:label="G_MASE_RS00885">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00885">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947877.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19165" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19165" fbc:name="MASE_RS19165" fbc:label="G_MASE_RS19165">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19165">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951357.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01530" fbc:name="MASE_RS01530" fbc:label="G_MASE_RS01530">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01530">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947997.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01735" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01735" fbc:name="MASE_RS01735" fbc:label="G_MASE_RS01735">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01735">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948038.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11700" fbc:name="MASE_RS11700" fbc:label="G_MASE_RS11700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949955.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08135" fbc:name="MASE_RS08135" fbc:label="G_MASE_RS08135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949255.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17525" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17525" fbc:name="MASE_RS17525" fbc:label="G_MASE_RS17525">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17525">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951039.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02915" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02915" fbc:name="MASE_RS02915" fbc:label="G_MASE_RS02915">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02915">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948265.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12465" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12465" fbc:name="MASE_RS12465" fbc:label="G_MASE_RS12465">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12465">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950103.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17520" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17520" fbc:name="MASE_RS17520" fbc:label="G_MASE_RS17520">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17520">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951038.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16800" fbc:name="MASE_RS16800" fbc:label="G_MASE_RS16800">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16800">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039226687.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19785" fbc:name="MASE_RS19785" fbc:label="G_MASE_RS19785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_015000154.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02960" fbc:name="MASE_RS02960" fbc:label="G_MASE_RS02960">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02960">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948273.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00895" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00895" fbc:name="MASE_RS00895" fbc:label="G_MASE_RS00895">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00895">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947879.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02065" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02065" fbc:name="MASE_RS02065" fbc:label="G_MASE_RS02065">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02065">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948099.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08585" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08585" fbc:name="MASE_RS08585" fbc:label="G_MASE_RS08585">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08585">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949344.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09085" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09085" fbc:name="MASE_RS09085" fbc:label="G_MASE_RS09085">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09085">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949444.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12535" fbc:name="MASE_RS12535" fbc:label="G_MASE_RS12535">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12535">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950116.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04450" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04450" fbc:name="MASE_RS04450" fbc:label="G_MASE_RS04450">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04450">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948563.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13635" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13635" fbc:name="MASE_RS13635" fbc:label="G_MASE_RS13635">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13635">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950328.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14600" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14600" fbc:name="MASE_RS14600" fbc:label="G_MASE_RS14600">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14600">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950509.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07220" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07220" fbc:name="MASE_RS07220" fbc:label="G_MASE_RS07220">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07220">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949085.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07180" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07180" fbc:name="MASE_RS07180" fbc:label="G_MASE_RS07180">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07180">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949077.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11855" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11855" fbc:name="MASE_RS11855" fbc:label="G_MASE_RS11855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949986.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13395" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13395" fbc:name="MASE_RS13395" fbc:label="G_MASE_RS13395">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13395">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950282.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06250" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06250" fbc:name="MASE_RS06250" fbc:label="G_MASE_RS06250">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06250">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948906.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17755" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17755" fbc:name="MASE_RS17755" fbc:label="G_MASE_RS17755">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17755">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951083.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08700" fbc:name="MASE_RS08700" fbc:label="G_MASE_RS08700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949367.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08095" fbc:name="MASE_RS08095" fbc:label="G_MASE_RS08095">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08095">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949249.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15625" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15625" fbc:name="MASE_RS15625" fbc:label="G_MASE_RS15625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949480.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11480" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11480" fbc:name="MASE_RS11480" fbc:label="G_MASE_RS11480">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11480">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949914.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09275" fbc:name="MASE_RS09275" fbc:label="G_MASE_RS09275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949480.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17625" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17625" fbc:name="MASE_RS17625" fbc:label="G_MASE_RS17625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951057.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07270" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07270" fbc:name="MASE_RS07270" fbc:label="G_MASE_RS07270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949094.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04380" fbc:name="MASE_RS04380" fbc:label="G_MASE_RS04380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948549.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10210" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10210" fbc:name="MASE_RS10210" fbc:label="G_MASE_RS10210">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10210">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949662.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01815" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01815" fbc:name="MASE_RS01815" fbc:label="G_MASE_RS01815">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01815">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948053.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12655" fbc:name="MASE_RS12655" fbc:label="G_MASE_RS12655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950140.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11530" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11530" fbc:name="MASE_RS11530" fbc:label="G_MASE_RS11530">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11530">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949923.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17335" fbc:name="MASE_RS17335" fbc:label="G_MASE_RS17335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951002.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15795" fbc:name="MASE_RS15795" fbc:label="G_MASE_RS15795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950718.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15800" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15800" fbc:name="MASE_RS15800" fbc:label="G_MASE_RS15800">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15800">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950719.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18740" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18740" fbc:name="MASE_RS18740" fbc:label="G_MASE_RS18740">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18740">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951273.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09070" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09070" fbc:name="MASE_RS09070" fbc:label="G_MASE_RS09070">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09070">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949441.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16785" fbc:name="MASE_RS16785" fbc:label="G_MASE_RS16785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950904.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14980" fbc:name="MASE_RS14980" fbc:label="G_MASE_RS14980">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14980">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950585.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10625" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10625" fbc:name="MASE_RS10625" fbc:label="G_MASE_RS10625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949744.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10620" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10620" fbc:name="MASE_RS10620" fbc:label="G_MASE_RS10620">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10620">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949743.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17655" fbc:name="MASE_RS17655" fbc:label="G_MASE_RS17655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951063.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00480" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00480" fbc:name="MASE_RS00480" fbc:label="G_MASE_RS00480">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00480">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947797.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05140" fbc:name="MASE_RS05140" fbc:label="G_MASE_RS05140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693407.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS17775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17775" fbc:name="MASE_RS17775" fbc:label="G_MASE_RS17775">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS17775">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951087.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11490" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11490" fbc:name="MASE_RS11490" fbc:label="G_MASE_RS11490">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11490">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949916.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18275" fbc:name="MASE_RS18275" fbc:label="G_MASE_RS18275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951186.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01135" fbc:name="MASE_RS01135" fbc:label="G_MASE_RS01135">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01135">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947927.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11175" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11175" fbc:name="MASE_RS11175" fbc:label="G_MASE_RS11175">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11175">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949853.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00315" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00315" fbc:name="MASE_RS00315" fbc:label="G_MASE_RS00315">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00315">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947765.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06645" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06645" fbc:name="MASE_RS06645" fbc:label="G_MASE_RS06645">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06645">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948978.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS01805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS01805" fbc:name="MASE_RS01805" fbc:label="G_MASE_RS01805">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS01805">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948051.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10910" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10910" fbc:name="MASE_RS10910" fbc:label="G_MASE_RS10910">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10910">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949799.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10125" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10125" fbc:name="MASE_RS10125" fbc:label="G_MASE_RS10125">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10125">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949645.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10340" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10340" fbc:name="MASE_RS10340" fbc:label="G_MASE_RS10340">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10340">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949688.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08545" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08545" fbc:name="MASE_RS08545" fbc:label="G_MASE_RS08545">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08545">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949336.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12665" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12665" fbc:name="MASE_RS12665" fbc:label="G_MASE_RS12665">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12665">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950142.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07005" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07005" fbc:name="MASE_RS07005" fbc:label="G_MASE_RS07005">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07005">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949044.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02510" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02510" fbc:name="MASE_RS02510" fbc:label="G_MASE_RS02510">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02510">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948183.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13030" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13030" fbc:name="MASE_RS13030" fbc:label="G_MASE_RS13030">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13030">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950209.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11730" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11730" fbc:name="MASE_RS11730" fbc:label="G_MASE_RS11730">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11730">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949961.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05580" fbc:name="MASE_RS05580" fbc:label="G_MASE_RS05580">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05580">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948774.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13495" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13495" fbc:name="MASE_RS13495" fbc:label="G_MASE_RS13495">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13495">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950300.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19215" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19215" fbc:name="MASE_RS19215" fbc:label="G_MASE_RS19215">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19215">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951366.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12165" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12165" fbc:name="MASE_RS12165" fbc:label="G_MASE_RS12165">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12165">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950048.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10785" fbc:name="MASE_RS10785" fbc:label="G_MASE_RS10785">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10785">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949774.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00460" fbc:name="MASE_RS00460" fbc:label="G_MASE_RS00460">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00460">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947793.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10335" fbc:name="MASE_RS10335" fbc:label="G_MASE_RS10335">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10335">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949687.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00470" fbc:name="MASE_RS00470" fbc:label="G_MASE_RS00470">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00470">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947795.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19280" fbc:name="MASE_RS19280" fbc:label="G_MASE_RS19280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19280">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693893.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02775" fbc:name="MASE_RS02775" fbc:label="G_MASE_RS02775">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02775">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948237.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18675" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18675" fbc:name="MASE_RS18675" fbc:label="G_MASE_RS18675">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18675">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012520077.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18680" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18680" fbc:name="MASE_RS18680" fbc:label="G_MASE_RS18680">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18680">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951262.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18685" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18685" fbc:name="MASE_RS18685" fbc:label="G_MASE_RS18685">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18685">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951263.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18690" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18690" fbc:name="MASE_RS18690" fbc:label="G_MASE_RS18690">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18690">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951264.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16980" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16980" fbc:name="MASE_RS16980" fbc:label="G_MASE_RS16980">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16980">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950933.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16985" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16985" fbc:name="MASE_RS16985" fbc:label="G_MASE_RS16985">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16985">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950934.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18105" fbc:name="MASE_RS18105" fbc:label="G_MASE_RS18105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951151.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18100" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18100" fbc:name="MASE_RS18100" fbc:label="G_MASE_RS18100">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18100">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951150.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09830" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09830" fbc:name="MASE_RS09830" fbc:label="G_MASE_RS09830">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09830">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949591.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09820" fbc:name="MASE_RS09820" fbc:label="G_MASE_RS09820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949589.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09835" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09835" fbc:name="MASE_RS09835" fbc:label="G_MASE_RS09835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949592.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09825" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09825" fbc:name="MASE_RS09825" fbc:label="G_MASE_RS09825">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09825">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949590.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09850" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09850" fbc:name="MASE_RS09850" fbc:label="G_MASE_RS09850">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09850">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949594.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02575" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02575" fbc:name="MASE_RS02575" fbc:label="G_MASE_RS02575">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02575">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948196.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02845" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02845" fbc:name="MASE_RS02845" fbc:label="G_MASE_RS02845">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02845">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948250.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS15550" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15550" fbc:name="MASE_RS15550" fbc:label="G_MASE_RS15550">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS15550">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950693.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19695" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19695" fbc:name="MASE_RS19695" fbc:label="G_MASE_RS19695">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19695">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951449.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19705" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19705" fbc:name="MASE_RS19705" fbc:label="G_MASE_RS19705">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19705">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951450.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19720" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19720" fbc:name="MASE_RS19720" fbc:label="G_MASE_RS19720">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19720">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012520222.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19690" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19690" fbc:name="MASE_RS19690" fbc:label="G_MASE_RS19690">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19690">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951448.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19710" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19710" fbc:name="MASE_RS19710" fbc:label="G_MASE_RS19710">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19710">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951451.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19730" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19730" fbc:name="MASE_RS19730" fbc:label="G_MASE_RS19730">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19730">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951453.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19700" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19700" fbc:name="MASE_RS19700" fbc:label="G_MASE_RS19700">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19700">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012520217.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19715" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19715" fbc:name="MASE_RS19715" fbc:label="G_MASE_RS19715">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19715">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951452.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19725" fbc:name="MASE_RS19725" fbc:label="G_MASE_RS19725">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19725">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_012520223.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03270" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03270" fbc:name="MASE_RS03270" fbc:label="G_MASE_RS03270">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03270">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948331.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03275" fbc:name="MASE_RS03275" fbc:label="G_MASE_RS03275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948332.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19300" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19300" fbc:name="MASE_RS19300" fbc:label="G_MASE_RS19300">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19300">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951383.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19310" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19310" fbc:name="MASE_RS19310" fbc:label="G_MASE_RS19310">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19310">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951385.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19315" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19315" fbc:name="MASE_RS19315" fbc:label="G_MASE_RS19315">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19315">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951386.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10775" fbc:name="MASE_RS10775" fbc:label="G_MASE_RS10775">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10775">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949772.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10795" fbc:name="MASE_RS10795" fbc:label="G_MASE_RS10795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949776.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10325" fbc:name="MASE_RS10325" fbc:label="G_MASE_RS10325">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10325">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949685.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07810" fbc:name="MASE_RS07810" fbc:label="G_MASE_RS07810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949194.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00295" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00295" fbc:name="MASE_RS00295" fbc:label="G_MASE_RS00295">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00295">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693648.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14630" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14630" fbc:name="MASE_RS14630" fbc:label="G_MASE_RS14630">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14630">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693832.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06255" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06255" fbc:name="MASE_RS06255" fbc:label="G_MASE_RS06255">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06255">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948907.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00795" fbc:name="MASE_RS00795" fbc:label="G_MASE_RS00795">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00795">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947858.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00455" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00455" fbc:name="MASE_RS00455" fbc:label="G_MASE_RS00455">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00455">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947792.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS07140" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07140" fbc:name="MASE_RS07140" fbc:label="G_MASE_RS07140">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS07140">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949069.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS04330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04330" fbc:name="MASE_RS04330" fbc:label="G_MASE_RS04330">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS04330">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948539.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16100" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16100" fbc:name="MASE_RS16100" fbc:label="G_MASE_RS16100">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16100">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950779.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16105" fbc:name="MASE_RS16105" fbc:label="G_MASE_RS16105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950780.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16090" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16090" fbc:name="MASE_RS16090" fbc:label="G_MASE_RS16090">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16090">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950777.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS13875" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13875" fbc:name="MASE_RS13875" fbc:label="G_MASE_RS13875">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS13875">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950376.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12810" fbc:name="MASE_RS12810" fbc:label="G_MASE_RS12810">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12810">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950167.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS11100" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11100" fbc:name="MASE_RS11100" fbc:label="G_MASE_RS11100">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS11100">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949838.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14955" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14955" fbc:name="MASE_RS14955" fbc:label="G_MASE_RS14955">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14955">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_039235311.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS03105" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03105" fbc:name="MASE_RS03105" fbc:label="G_MASE_RS03105">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS03105">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948300.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08595" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08595" fbc:name="MASE_RS08595" fbc:label="G_MASE_RS08595">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08595">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949346.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS08425" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08425" fbc:name="MASE_RS08425" fbc:label="G_MASE_RS08425">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS08425">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949312.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05150" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05150" fbc:name="MASE_RS05150" fbc:label="G_MASE_RS05150">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05150">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_187289707.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05650" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05650" fbc:name="MASE_RS05650" fbc:label="G_MASE_RS05650">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05650">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948787.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05655" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05655" fbc:name="MASE_RS05655" fbc:label="G_MASE_RS05655">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05655">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948788.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS09380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09380" fbc:name="MASE_RS09380" fbc:label="G_MASE_RS09380">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS09380">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949501.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS10880" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10880" fbc:name="MASE_RS10880" fbc:label="G_MASE_RS10880">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS10880">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949793.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS00820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00820" fbc:name="MASE_RS00820" fbc:label="G_MASE_RS00820">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS00820">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947863.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS14625" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14625" fbc:name="MASE_RS14625" fbc:label="G_MASE_RS14625">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS14625">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950514.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS06245" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06245" fbc:name="MASE_RS06245" fbc:label="G_MASE_RS06245">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS06245">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948905.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16085" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16085" fbc:name="MASE_RS16085" fbc:label="G_MASE_RS16085">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16085">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950776.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS18670" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18670" fbc:name="MASE_RS18670" fbc:label="G_MASE_RS18670">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS18670">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951261.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS19275" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19275" fbc:name="MASE_RS19275" fbc:label="G_MASE_RS19275">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS19275">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951378.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS16095" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16095" fbc:name="MASE_RS16095" fbc:label="G_MASE_RS16095">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS16095">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950778.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS05420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05420" fbc:name="MASE_RS05420" fbc:label="G_MASE_RS05420">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS05420">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232362815.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS02325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS02325" fbc:name="MASE_RS02325" fbc:label="G_MASE_RS02325">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS02325">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948149.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12850" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12850" fbc:name="MASE_RS12850" fbc:label="G_MASE_RS12850">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12850">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950173.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12870" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12870" fbc:name="MASE_RS12870" fbc:label="G_MASE_RS12870">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12870">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950177.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>

--- a/model.xml
+++ b/model.xml
@@ -37895,10 +37895,7 @@
           <speciesReference species="M_cpd01710_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04055"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04050"/>
-          </fbc:and>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04050"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03062_c0" sboTerm="SBO:0000176" id="R_rxn03062_c0" name="3-Isopropylmalate:NAD+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -42884,10 +42881,7 @@
           <speciesReference species="M_cpd01710_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04050"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04055"/>
-          </fbc:or>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04050"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01370_c0" sboTerm="SBO:0000176" id="R_rxn01370_c0" name="dGTP:uridine 5&apos;-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -45019,10 +45013,7 @@
           <speciesReference species="M_cpd00581_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19430"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03805"/>
-          </fbc:and>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03805"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00770_c0" sboTerm="SBO:0000176" id="R_rxn00770_c0" name="ATP:D-ribose-5-phosphate diphosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -68935,19 +68926,6 @@
         </annotation>
       </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS04055" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04055" fbc:name="MASE_RS04055" fbc:label="G_MASE_RS04055"/>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04050" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04050" fbc:name="MASE_RS04050" fbc:label="G_MASE_RS04050">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS04050">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948483.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS04060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04060" fbc:name="MASE_RS04060" fbc:label="G_MASE_RS04060">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -70703,7 +70681,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19430" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19430" fbc:name="MASE_RS19430" fbc:label="G_MASE_RS19430"/>
       <fbc:geneProduct metaid="meta_G_MASE_RS03805" sboTerm="SBO:0000243" fbc:id="G_MASE_RS03805" fbc:name="MASE_RS03805" fbc:label="G_MASE_RS03805">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">

--- a/model.xml
+++ b/model.xml
@@ -33919,31 +33919,6 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn09988_c0" sboTerm="SBO:0000176" id="R_rxn09988_c0" name="alpha-N-arabinofuranosidase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn09988_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09988"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136139"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.55"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd12115_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00224_c0" stoichiometry="3" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19195"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn08798_c0" sboTerm="SBO:0000176" id="R_rxn08798_c0" name="Lysophospholipase L1 (2-acylglycerophosphotidate, n-C14:1) (periplasm) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -67078,7 +67053,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19195" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19195" fbc:name="MASE_RS19195" fbc:label="G_MASE_RS19195"/>
       <fbc:geneProduct metaid="meta_G_MASE_RS16580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16580" fbc:name="MASE_RS16580" fbc:label="G_MASE_RS16580">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -74128,6 +74102,7 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
+      <fbc:geneProduct fbc:id="G_MASE_RS04050" fbc:name="G_MASE_RS04050" fbc:label="G_MASE_RS04050"/>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>


### PR DESCRIPTION
This pull request:
- Adds RefSeq non-redundant protein accessions as annotations to all but one of the genes that are currently in the model
- Removes `MASE_RS04055` from the GPRs of `rxn02811_c0` and `rxn02789_c0`
- Removes `MASE_RS19430` from the GPR of `rxn02085_c0`
- Changes the GPR of `rxn00558_c0` from `MASE_RS14470` to `MASE_RS01330`
- Removes `rxn09988_c0` from the model
- Removes `MASE_RS04055`, `MASE_RS19430`, `MASE_RS19195`, `MASE_RS14470` from the model

These changes facilitate [mapping genes between models](https://github.com/C-CoMP-STC/GEM-mit1002/pull/223) for different strains of _Alteromonas macleodii_.

`MASE_RS04055` and `MASE_RS19430` were annotated as pseudogenes, and `rxn02811_c0`, `rxn02789_c0`, and `rxn02085_c0` were all associated with other genes, so removing these genes from the model doesn't leave any reactions with empty GPRs.

`MASE_RS14470` was also annotated as a pseudogene, but it was the only gene associated with `rxn00558_c0`, which is phosphoglucoisomerase, so removing that reaction and leaving it associated with no genes both seemed problematic. No genes in the ATCC27126 genome appeared to be annotated with the E.C. number for phosphoglucoisomerase (5.3.1.9), but `MASE_RS01330` was annotated with 5.3.1.-, which seems close enough to me, so I just replaced `MASE_RS14470` with `MASE_RS01330` in the GPR of `rxn00558_c0` so that I could remove `MASE_RS14470` without causing problems. I also noticed that the pangenome analysis annotated a gene as [K13810](https://www.kegg.jp/entry/K13810), which can catalyze 5.3.1.9, so I may have a better GPR for `rxn00558_c0` after this PR is merged and I can systematically map changes that I made to the MIT1002 model to this one.

I couldn't find `MASE_RS19195` in any of the genome annotation files for ATCC27126, and the only reaction that it's associated with (`rxn09988_c0`) is a dead-end (no other reactions in the model produce or consume arabinan (`cpd12115_c0`) or arabinose (`cpd00224_c0`) that isn't associated with any other genes, so it's not clear that there's strong evidence that this strain can actually catalyze that reaction. It'll also be easy enough to add this reaction back if such evidence appears later.

The one gene that is currently in the model that this PR doesn't add a protein accession for or remove is `MASE_RS12365`, which was annotated as a pseudogene, and is the only gene associated with `rxn03909_c0`. I could find no evidence that any other genes in the ATCC27126 genome are capable of catalyzing rxn03909_c0 (E.C. 2.2.1.7), which is required for thiamine biosynthesis, so I'm just leaving it alone for now. Being able to map all but one gene in this model to the genes in the pangenome analysis and the MIT1002 model is still going to be useful.