### PR TITLE
Copy changes made to reactions in the MIT1002 model

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -231,25 +231,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00213_c0" sboTerm="SBO:0000247" id="M_cpd00213_c0" name="Lipoamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C8H15NOS2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00213_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00213"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C8H15NOS2/c9-8(10)4-2-1-3-7-5-6-11-12-7/h7H,1-6H2,(H2,9,10)/t7-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/FCCDDURTIIUXBY-SSDOTTSWSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/lpam"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00248"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1024"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LIPOAMIDE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd14700_c0" sboTerm="SBO:0000247" id="M_cpd14700_c0" name="2-Methyl-1-hydroxypropyl-TPP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H25N4O8P2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -7584,25 +7565,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00449_c0" sboTerm="SBO:0000247" id="M_cpd00449_c0" name="Dihydrolipoamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C8H17NOS2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00449_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00449"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C8H17NOS2/c9-8(10)4-2-1-3-7(12)5-6-11/h7,11-12H,1-6H2,(H2,9,10)/t7-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/VLYUGYAKYZETRF-SSDOTTSWSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/dhlam"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00579"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1277"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIHYDROLIPOAMIDE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00481_c0" sboTerm="SBO:0000247" id="M_cpd00481_c0" name="Isobutyryl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C25H38N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -10811,47 +10773,6 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15603"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8666"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd12115_c0" sboTerm="SBO:0000247" id="M_cpd12115_c0" name="Arabinan [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C15H26O13">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd12115_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd12115"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/Larab"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/G00502"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02474"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6179"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM491556"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM42463"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00224_c0" sboTerm="SBO:0000247" id="M_cpd00224_c0" name="L-Arabinose [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H10O5">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00224_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00224"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C5H10O5/c6-2-1-10-5(9)4(8)3(2)7/h2-9H,1H2/t2-,3-,4+,5?/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/SRBFZHDQGSBBOR-HWQSCIPKSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/arab__L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00259"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM722808"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM91126"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM461"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:L-arabinopyranose"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-15699"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -15669,38 +15590,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd12005_c0" sboTerm="SBO:0000247" id="M_cpd12005_c0" name="Lipoylprotein [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="CHRS2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd12005_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd12005"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/lpro"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02051"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM998"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd11830_c0" sboTerm="SBO:0000247" id="M_cpd11830_c0" name="S-Aminomethyldihydrolipoylprotein [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C2H7NRS2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd11830_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11830"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/alpro"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01242"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM81221"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd11621_c0" sboTerm="SBO:0000247" id="M_cpd11621_c0" name="Oxidizedferredoxin [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="6" fbc:chemicalFormula="Fe2R4S6">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -16942,22 +16831,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd12225_c0" sboTerm="SBO:0000247" id="M_cpd12225_c0" name="Dihydrolipolprotein [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="CH3RS2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd12225_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd12225"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/dhlpro"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02972"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1663"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd03585_c0" sboTerm="SBO:0000247" id="M_cpd03585_c0" name="KDO-lipid IV(A) [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-5" fbc:chemicalFormula="C76H137N2O30P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -17960,23 +17833,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C12248"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1805"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-5821"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15277_c0" sboTerm="SBO:0000247" id="M_cpd15277_c0" name="Palmitoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H51N2O8PRS">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15277_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15277"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/palmACP"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM162320"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Palmitoyl-ACPs"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Palmitoyl-PKS2"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19429,26 +19285,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd28259_c0" sboTerm="SBO:0000247" id="M_cpd28259_c0" name="Thiocarboxyadenylated-ThiS-Proteins [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C4H7N2O2RS">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd28259_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd28259"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C20728"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM148019"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM9152"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Thiocarboxyadenylated-ThiS-Proteins"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Thiocarboxylated-URM1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Thiocarboxylated-CysO"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Thiocarboxylated-TtuB"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd21479_c0" sboTerm="SBO:0000247" id="M_cpd21479_c0" name="2-[(2R,5Z)-2-Carboxy-4-methylthiazol-5(2H)-ylidene]ethyl phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C7H7NO6PS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -20339,26 +20175,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/inchikey/GLNFBGKHGHVPRL-IYOUNJFTSA-L"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM165083"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-18260"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd01046_c0" sboTerm="SBO:0000247" id="M_cpd01046_c0" name="Allysine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H11NO3">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01046_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01046"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C6H11NO3/c7-5(6(9)10)3-1-2-4-8/h4-5H,1-3,7H2,(H,9,10)/t5-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/GFXYTQPNNXGICT-YFKPBYRVSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/L2aadp6sa"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04076"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM89905"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM219"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALLYSINE"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21563,20 +21379,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15793_c0" sboTerm="SBO:0000247" id="M_cpd15793_c0" name="Stearoylcardiolipin (B. subtilis) [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C81H156O17P2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15793_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15793"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6440"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd11416_c0" sboTerm="SBO:0000247" id="M_cpd11416_c0" name="Biomass [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="null">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -21585,26 +21387,6 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11416"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/BIOMASS"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd01997_c0" sboTerm="SBO:0000247" id="M_cpd01997_c0" name="Dimethylbenzimidazole [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C9H10N2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01997_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01997"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C9H10N2/c1-6-3-8-9(4-7(6)2)11-5-10-8/h3-5H,1-2H3,(H,10,11)"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/LJUQGASMPRMWIW-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/dmbzid"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03114"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM50981"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1531"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIMETHYLBENZIMIDAZOLE"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>

--- a/model.xml
+++ b/model.xml
@@ -21640,6 +21640,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR140085"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:H2PTEROATESYNTH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.15"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00796"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24102"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18824"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18974"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13941"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13939"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21680,6 +21687,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100450"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTATHIONE-SYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21456"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01920"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21714,6 +21723,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142260"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111208"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21750,6 +21762,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100752"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HYPOXANPRIBOSYLTRAN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15780"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19836"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00760"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21783,6 +21798,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104275"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SERINE-O-ACETTRAN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.30"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23304"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00640"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19726"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21821,6 +21839,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11832"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.14"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13800"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13809"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13799"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00945"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21880,6 +21902,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139325"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105037"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.1.227"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02563"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21909,6 +21932,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100785"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ISOCHORMAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.3.2.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01252"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21980,6 +22004,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141849"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTCYSLIG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11205"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11204"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01919"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06048"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22015,6 +22043,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101939"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DCDPKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22048,6 +22078,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103099"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PEPCARBOXYKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.49"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01610"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22109,6 +22140,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102429"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108063"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00161"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00162"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00163"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22178,6 +22212,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR140588"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-15910"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.20"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12316"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12317"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12047"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01187"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22235,6 +22273,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104759"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DTDPDEHYDRHAMEPIM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.1.3.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23987"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01790"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22266,6 +22306,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14271"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.35"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.211"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07516"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22325,6 +22372,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00139"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106405"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22385,6 +22433,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109875"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PDXJ-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.99.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03474"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22420,6 +22469,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8642"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.42"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00031"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22451,6 +22501,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138516"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR137943"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.2.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05605"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22511,6 +22562,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SUCCORNTRANSAM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.81"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00840"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22542,6 +22594,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96237"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:BADH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00130"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22679,6 +22733,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-7913"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.14"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13800"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13809"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13799"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00945"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22713,6 +22771,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR140008"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:AMPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.3.2.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01756"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22775,6 +22834,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103119"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:P-PANTOCYSLIG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21977"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13038"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22811,6 +22872,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105063"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UGD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00012"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22844,6 +22906,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100277"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.2.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00931"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12657"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22911,6 +22975,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95259"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:N-ACETYLTRANSFER-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22477"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00620"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11067"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22478"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22476"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00618"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14682"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14681"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00619"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -22953,6 +23026,17 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5292"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08723"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07023"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25434"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06952"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08722"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23007,13 +23091,13 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11265"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn01199_c0" sboTerm="SBO:0000176" id="R_rxn01199_c0" name="ATP:D-xylulose 5-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn01199_c0" sboTerm="SBO:0000176" id="R_rxn01199_c0" name="ATP:D-xylulose 5-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn01199_c0">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01199"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01199_c0"/>
                   <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/XYLK"/>
                   <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/XKS1"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01639"/>
@@ -23054,6 +23138,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/16112"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138694"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00850"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24182"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16370"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21071"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23117,6 +23205,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03238"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108040"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00850"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16370"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23151,6 +23241,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-2902"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.18"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.27"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00140"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23185,6 +23276,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95852"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HISTAMINOTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00817"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23215,6 +23307,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105141"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-10642"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.37"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01599"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23247,6 +23340,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR125603"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:H2NEOPTERINALDOL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01633"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13939"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09739"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23307,6 +23404,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96088"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.3.16"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.3.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03334"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00278"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23340,6 +23439,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.67"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08310"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19965"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23370,6 +23471,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95483"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14270"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00759"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23539,6 +23641,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/24810"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106867"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01687"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23566,11 +23669,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HOCHL3"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04537"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94888"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.59"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.58"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.61"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16363"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01716"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02372"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23631,6 +23738,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97178"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIOHBUTANONEPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.99.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02858"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14652"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23661,6 +23770,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R06093"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99984"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07407"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01189"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23748,6 +23860,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141951"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12492"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01426"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23782,6 +23895,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101000"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.23"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.108"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01229"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12111"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01190"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23814,6 +23930,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103400"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:QUINOLINATE-SYNTHA-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.72"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03517"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23848,6 +23965,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-2962"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.-.-.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.284"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00121"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23882,6 +24000,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:METHYLTHIOADENOSINE-NUCLEOSIDASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.9"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01243"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01244"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18284"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23922,6 +24043,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:4.3.1.17-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.3.1.19"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.3.1.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01752"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01754"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17989"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23982,6 +24106,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95132"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DARAB5PISOM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02467"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06041"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24102,6 +24228,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97842"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ERYTH4PDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.72"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03472"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24162,6 +24289,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/20807"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101662"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.27"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00140"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24221,6 +24349,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102190"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:OROTPDECARB-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.23"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13421"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01591"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24321,6 +24451,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101752"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141868"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.20"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25004"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25009"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24439,6 +24571,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100747"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-7682"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.17.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13482"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00087"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13483"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13481"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13479"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11178"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00106"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13480"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11177"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24479,6 +24620,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.19"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.66"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01519"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24540,6 +24682,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-2381"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.20"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01696"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01695"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13222"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24636,6 +24782,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104762"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TETRAACYLDISACC4KIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.130"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00912"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24698,6 +24845,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:KDO-8PSYNTH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.55"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01627"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24770,6 +24918,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96085"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ASPARTATEKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.2.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00928"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12524"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12525"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12526"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24862,6 +25014,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/25146"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100656"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.7.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01556"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24896,6 +25049,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103355"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PMPOXI-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23998"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00275"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24970,6 +25125,18 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5038"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.4.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.4.53"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01120"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13293"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13294"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19021"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03651"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18438"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13298"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13755"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18437"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18436"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18283"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13296"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25002,11 +25169,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/42251"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109245"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9516"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.41"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.180"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00647"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09458"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25047,6 +25216,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100639"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HISTIDINE-AMMONIA-LYASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.3.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01745"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25080,6 +25250,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109092"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14277"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07508"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00632"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25138,6 +25312,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.1.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.1.25"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.20"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00691"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09844"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25195,6 +25371,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95636"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.49"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.47"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13034"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01738"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01740"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17069"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10150"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25232,6 +25413,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96059"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ASNSYNB-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.5.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01953"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25258,7 +25440,7 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn02270_c0" sboTerm="SBO:0000176" id="R_rxn02270_c0" name="Branched-chain acyl-CoA dehydrogenase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn02270_c0" sboTerm="SBO:0000176" id="R_rxn02270_c0" name="Branched-chain acyl-CoA dehydrogenase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn02270_c0">
@@ -25327,6 +25509,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108089"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105357"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00164"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01616"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25420,6 +25604,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN66-555"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.51"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01922"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25489,6 +25674,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2-ISOPROPYLMALATESYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.3.13"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01649"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25520,6 +25706,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/13504"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96330"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.14"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11262"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11263"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01961"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25560,6 +25749,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACSERLY-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.47"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.65"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01738"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10150"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13034"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17069"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25591,6 +25784,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104379"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SHIKIMATE-KINASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.71"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00891"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13829"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13830"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25621,6 +25817,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102027"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14227"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18551"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18550"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25660,6 +25864,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103121"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PREPHENATEDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00220"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04517"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14187"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24018"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25696,6 +25904,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138572"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.7.7.13-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16011"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16881"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00971"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00966"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25730,6 +25942,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95159"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ADENYLYLSULFKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00860"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13811"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00955"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25766,6 +25981,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.3.6"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00232"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00255"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00249"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06445"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25806,6 +26025,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142263"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101697"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25840,6 +26062,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97143"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIAMINOPIMEPIM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.1.1.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01778"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25872,6 +26095,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103109"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PPGPPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.7.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21138"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01139"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25945,6 +26170,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.1.15"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.6.6.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00362"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17877"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26138"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00363"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00361"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26139"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26073,6 +26304,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:OHMETHYLBILANESYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.61"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.3.1.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01749"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26105,6 +26337,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-7957"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.2.15"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.2.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00925"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26136,11 +26369,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04957"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109248"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9523"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.41"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.180"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00647"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09458"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26272,6 +26507,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103371"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PEPDEPHOS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.40"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00873"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26340,6 +26577,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97762"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DEPHOSPHOCOAKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.24"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02318"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00859"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26408,6 +26647,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01519"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26442,6 +26682,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96132"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ATPPHOSPHORIBOSYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00765"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02502"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26477,6 +26719,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14106"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.86"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.99.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00053"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26570,6 +26813,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GAPDHSYNEC-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.59"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00134"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10705"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00150"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26604,6 +26850,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-10949"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5408"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10047"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18649"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01092"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26662,6 +26911,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104649"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SULFITE-OXIDASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.3.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00387"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26753,6 +27003,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04383"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108856"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01815"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26782,6 +27033,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105139"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UROGENIIISYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.75"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01719"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13543"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13542"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26873,6 +27127,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11662"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.35"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.211"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15016"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07516"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26918,6 +27179,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR132731"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109724"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01000"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26951,6 +27213,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95450"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ADENYL-KIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18532"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00939"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27015,6 +27280,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97447"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-DEHYDROQUINATE-SYNTHASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.3.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13829"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13830"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01735"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27048,6 +27316,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11988"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUC1PADENYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.27"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00975"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27078,7 +27347,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109080"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9661"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00208"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02371"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27111,6 +27383,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR134526"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:R344-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00798"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19221"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27148,6 +27422,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139018"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYOHMETRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.2.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00600"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27181,6 +27456,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95948"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ARGSUCCINLYA-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.3.2.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01755"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14681"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27243,6 +27520,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100642"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HISTIDPHOS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.15"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01089"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18649"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04486"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05602"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27308,6 +27589,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03237"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108039"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00850"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16370"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27342,6 +27625,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100628"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HOMOGENTISATE-12-DIOXYGENASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.13.11.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00451"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27401,6 +27685,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.3.6"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00232"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00255"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00249"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06445"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27444,6 +27732,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-7609"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:5-NUCLEOTID-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K20881"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27481,6 +27776,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104761"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DTDPGLUCDEHYDRAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.46"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01710"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27515,6 +27811,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12445"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.41"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.30"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22393"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23470"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00484"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22394"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05368"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27611,6 +27912,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95210"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETALD-DEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00132"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04072"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18366"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04073"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04021"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27650,6 +27956,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97830"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DXPREDISOM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.267"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00099"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27679,6 +27986,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106555"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-13680"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.15"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01437"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27714,6 +28022,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95194"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETYL-COA-ACETYLTRANSFER-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00626"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07508"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00632"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27750,6 +28063,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/31214"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104321"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00789"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27785,6 +28099,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102231"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:OROPRIBTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00762"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13421"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27813,7 +28129,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HBUHL1"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04428"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94886"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.58"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.59"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16363"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01716"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02372"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27843,6 +28167,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04639"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105370"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22391"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09007"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01495"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27877,6 +28204,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/11067"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138346"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01086"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01622"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03841"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04041"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11532"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02446"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27906,6 +28239,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/14456"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109761"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.262"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00097"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -27978,6 +28312,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN66-3"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00149"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00128"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28043,6 +28380,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.1.1.178-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.35"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.178"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08683"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00022"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28082,6 +28424,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95843"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ANTHRANSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.27"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13497"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01658"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01657"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13503"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13501"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01656"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28177,6 +28525,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/30794"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95613"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.40"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00873"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28239,6 +28589,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102038"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14142"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07023"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06952"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08722"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28312,6 +28671,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99877"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYC3PDEHYDROGBIOSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.94"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00057"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28344,6 +28704,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100913"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.3.1.180-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.180"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00648"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18473"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28493,6 +28855,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107887"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HISTOLDEHYD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.23"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00013"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14152"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28527,6 +28891,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103217"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PHOSPHORIBULOKINASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00855"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28611,6 +28976,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03970"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105361"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.2.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00681"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18592"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28727,6 +29094,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138486"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GMP-SYN-GLUT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.5.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01951"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28889,6 +29257,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100455"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GTP-CYCLOHYDRO-II-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01497"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14652"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -28923,6 +29293,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107649"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97451"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29023,6 +29394,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR126511"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-10815"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.13.11.27"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00457"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29129,6 +29501,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9384"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.48"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10764"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01739"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29161,9 +29535,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94879"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9537"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.59"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.61"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16363"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01716"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02372"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29193,6 +29572,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R05046"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138945"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22391"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09007"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01495"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29285,6 +29667,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138584"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.31"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K27797"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01659"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29350,6 +29734,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.1.4.2-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.4.2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.4.46"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18696"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18695"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01126"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29384,6 +29771,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95618"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.44"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00830"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14272"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00827"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29467,6 +29857,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02026"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95622"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138033"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01739"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01740"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29541,11 +29933,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04963"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109254"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9531"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.41"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.180"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00647"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09458"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29583,6 +29977,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-13616"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.74"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13767"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29652,6 +30054,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107307"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:METHYLGLUTACONYL-COA-HYDRATASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.18"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13766"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05607"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29685,6 +30089,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101749"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:METHYLENETHFDEHYDROG-NADP-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01491"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00300"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00288"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29712,6 +30119,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/FAS1_7_c"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R10700"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR114020"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29775,6 +30184,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100933"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:KDO-8PPHOSPHAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.45"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03270"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29867,6 +30277,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97890"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.74"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13767"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -29907,6 +30325,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TSA-REDUCT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5289"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.60"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00042"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30031,6 +30450,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103187"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139796"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.99.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18318"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18319"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30154,11 +30575,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04726"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109082"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9535"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.41"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.180"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00647"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09458"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30196,6 +30619,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-901"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.17.1.4"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.204"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13482"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00087"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13483"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13481"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13479"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11178"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00106"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13480"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11177"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30233,6 +30665,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/13248"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100789"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01637"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30295,6 +30728,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97428"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIHYDROOROT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.2.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01465"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11540"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30331,6 +30766,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138611"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101555"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.1.14"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00549"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30390,6 +30826,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:AMACETOXID-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.3.21"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.3.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00274"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00276"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30480,6 +30918,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95656"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107585"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.61"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00658"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01616"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30512,6 +30952,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100735"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HOMOSERDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00003"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12525"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12524"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30545,6 +30988,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96039"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00133"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30584,6 +31028,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PPPGPPHYDRO-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.40"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01524"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01514"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30622,6 +31068,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MALATE-DEH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.299"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.37"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00024"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00026"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00025"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30656,6 +31105,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101040"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:L-LACTATE-DEHYDROGENASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.27"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00016"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30762,6 +31212,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CYTIDINEKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.48"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00876"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30796,6 +31247,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14025"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:5-NUCLEOTID-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08723"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25434"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30837,6 +31296,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138582"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:METHYLISOCITRATE-LYASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.30"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03417"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01637"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30864,6 +31325,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111209"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142262"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30898,6 +31362,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103122"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PREPHENATE-DEHYDROGENASE-NADP+-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00211"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30933,6 +31398,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103429"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RIBOFLAVINKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.26"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00861"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11753"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K20884"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30964,6 +31432,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104918"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRIOSEPISOMERIZATION-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01803"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -30993,6 +31462,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SEDOBISALDOL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01624"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11645"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01623"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31112,6 +31584,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103095"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PORPHOBILSYNTH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.24"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01698"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31140,6 +31613,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/54731"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95220"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.4.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18472"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15036"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11262"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01962"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01963"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31242,6 +31720,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100547"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.35"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.211"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07516"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31275,6 +31760,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R05590"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109702"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01426"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31344,6 +31830,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141973"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PANTEPADENYLYLTRAN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02318"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02201"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00954"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31464,6 +31953,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103154"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HISTCYCLOHYD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01496"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11755"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14152"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31495,6 +31987,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:KDPGALDOL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.14"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11395"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17463"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01625"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31528,6 +32023,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104373"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIMETHUROPORDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.76"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24866"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02304"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02302"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31565,6 +32063,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141930"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DTDPGLUCOSEPP-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.24"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23144"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00973"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31633,6 +32133,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96228"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:BRANCHED-CHAINAMINOTRANSFERILEU-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.42"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00826"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31693,6 +32194,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138702"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14206"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.14.16.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00500"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31724,6 +32226,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/30070"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96238"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00130"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31758,6 +32262,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14272"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.74"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13767"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31826,6 +32338,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107304"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.1.1.34-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.34"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00021"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31863,6 +32376,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/13240"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138476"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00820"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31891,6 +32405,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100905"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR134506"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00053"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -31926,6 +32441,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97501"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LUMAZINESYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.78"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00794"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32015,6 +32531,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95625"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ADENOSYLHOMOCYSTEINE-NUCLEOSIDASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01243"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18284"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32086,6 +32604,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103140"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PEPSYNTH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.9.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01007"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32144,6 +32663,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95696"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:D-ALANINE-AMINOTRANSFERASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.21"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00824"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32179,6 +32699,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104714"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THREDEHYD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.3.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01754"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17989"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32244,6 +32766,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96708"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CHORISMATEMUT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.99.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04516"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13853"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06208"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14170"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04093"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01850"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04092"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14187"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32284,6 +32815,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11505"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUC1PURIDYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22920"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00963"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12447"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32375,6 +32909,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99850"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GSAAMINOTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.3.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01845"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32402,6 +32937,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106809"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RIB5PISOM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01808"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01807"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32435,6 +32972,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SHIKIMATE-5-DEHYDROGENASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.25"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.282"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13830"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05887"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00014"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13832"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32497,7 +33038,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04961"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109252"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00208"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02371"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32561,6 +33105,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9087"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.84"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19745"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14469"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15020"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32625,6 +33172,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.11"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.144"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.56"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00850"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16370"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00917"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21071"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32694,6 +33245,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95812"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GUANIDINOBUTANAMIDE-NH3-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01426"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32723,6 +33275,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/23075"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103096"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.31"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01595"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32758,6 +33311,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-363"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01239"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32791,6 +33345,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ADENPRIBOSYLTRAN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00759"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32823,6 +33378,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100287"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PRPPAMIDOTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.14"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00764"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32857,6 +33413,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101424"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-302"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.6.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12506"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01770"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32918,6 +33476,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NUCLEOSIDE-DIP-KIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GDPKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32951,6 +33511,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.6.1.19-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04765"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06287"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07043"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25435"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01513"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -32982,6 +33547,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104504"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SERINE--PYRUVATE-AMINOTRANSFERASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.51"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00830"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13290"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33077,6 +33644,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103169"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PRIBFAICARPISOM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24017"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01814"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33129,6 +33698,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R05048"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105383"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22391"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09007"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01495"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33186,8 +33758,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04543"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94946"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.100"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00059"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11539"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33248,6 +33823,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95528"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NAG6PDEACET-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01443"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33281,6 +33857,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139055"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.1.4.14-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.4.14"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08682"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33314,6 +33891,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.1.1.127-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.127"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.125"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00065"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33348,6 +33926,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104635"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SUCCCOASYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.2.1.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01903"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01902"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33388,6 +33968,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.3"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00260"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15371"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00261"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33418,6 +34001,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01098"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100002"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.3.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04618"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33455,6 +34039,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138187"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THIOSULFATE-SULFURTRANSFERASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01011"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02439"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33487,6 +34073,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR137949"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:IMIDAZOLONEPROPIONASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.2.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01468"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33524,6 +34111,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:5-NUCLEOTID-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:AMP-DEPHOSPHORYLATION-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33559,6 +34152,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.23"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.9"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00271"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00263"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33590,6 +34185,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R08555"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95273"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.126"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07106"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33652,6 +34248,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.9"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.10"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01942"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03524"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01947"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33776,6 +34375,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101407"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:S-ADENMETSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00789"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33811,6 +34411,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97817"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DURIDKI-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.21"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00857"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05961"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -33868,6 +34470,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100692"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-305"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01816"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34004,6 +34607,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.5.1.39-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12945"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.39"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06125"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34196,6 +34800,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107584"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIHYDLIPACETRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00627"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34227,8 +34832,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR122850"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9532"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.100"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00059"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11539"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34261,6 +34869,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94940"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-OXOADIPATE-COA-TRANSFERASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.3.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01032"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01031"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34296,6 +34906,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95940"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ARGDECARBOX-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02626"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01583"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01585"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01584"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34328,6 +34942,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HEMN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.98.3"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02495"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34361,6 +34976,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100453"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GTP-CYCLOHYDRO-I-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22391"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09007"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01495"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34457,6 +35075,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105217"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:VALINE-PYRUVATE-AMINOTRANSFER-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.66"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14260"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00835"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34491,6 +35111,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100664"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:OHMETPYRKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.49"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21219"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00941"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00877"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14153"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34620,6 +35244,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101119"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LIPIDADISACCHARIDESYNTH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.1.182"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00748"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34653,6 +35278,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PREPHENATEDEHYDRAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.51"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.91"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04518"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05359"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01713"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14170"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34760,6 +35389,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14026"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.91"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08723"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24242"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25434"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34822,6 +35460,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.1.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.1.25"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.20"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00691"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09844"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -34852,6 +35492,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107151"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TSA-REDUCT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.60"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00042"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35010,6 +35651,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100737"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HOMOSERKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.39"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02203"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00872"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02204"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35041,6 +35685,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96115"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ARGININE-N-SUCCINYLTRANSFERASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.109"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00673"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35105,6 +35750,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101254"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LYSINE-23-AMINOMUTASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.3.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01843"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35132,6 +35778,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/14732"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99459"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16306"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11645"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01622"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01624"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01623"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16305"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35200,6 +35852,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12198"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01510"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14642"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35232,6 +35887,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96558"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.7.1.148-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.148"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00919"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35292,6 +35948,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102538"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PHOSGLYPHOS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.2.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00927"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35326,6 +35983,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR140004"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ADENYLOSUCCINATE-SYNTHASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01939"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35365,6 +36023,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5224"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CARBODEHYDRAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01674"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01672"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01743"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18245"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01673"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18246"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35403,6 +36067,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-7607"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.99"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K20881"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18550"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35441,6 +36113,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101551"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:METHGLYSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.3.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01734"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35475,6 +36148,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102057"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DGTPTRIPHYDRO-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.5.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01129"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35546,6 +36220,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-10949"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10047"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18649"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01092"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35577,6 +36254,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR115902"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GALACTUROISOM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01812"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35607,6 +36285,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96709"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CHORISMATE-SYNTHASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01736"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35823,6 +36502,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138907"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDPGLUCEPIM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.1.3.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17716"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01784"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35857,6 +36538,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101748"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:METHENYLTHFCYCLOHYDRO-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01491"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13403"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01500"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00288"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35885,6 +36570,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141957"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139137"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.2.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22596"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00682"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -35962,6 +36649,18 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.57"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11358"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00817"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05821"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14455"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00832"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14454"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00813"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00811"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15849"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00815"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00838"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00812"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36000,6 +36699,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95856"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.6.1.41-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.41"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01525"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36028,7 +36728,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04429"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108883"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00208"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02371"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36065,6 +36768,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.10"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.2.1.11"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01942"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03524"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01947"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36130,6 +36836,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95297"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.19"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.56"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01654"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36164,6 +36871,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96711"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CHORPYRLY-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.40"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18240"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03181"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36221,6 +36930,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95256"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETYLGLUTKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.2.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00930"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12659"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22478"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36314,6 +37026,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.3.6"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00232"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00255"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00249"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06445"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36359,6 +37075,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GMKALT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.12"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00942"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36392,6 +37109,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138890"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDP-NACMURALGLDAPLIG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01928"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15792"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36426,6 +37145,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103319"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PHOSACETYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13788"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04020"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00625"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15024"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36491,6 +37214,17 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THYMIDYLATE-5-PHOSPHATASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.35"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08723"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07023"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25434"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06952"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08722"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36664,6 +37398,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101969"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NMNAMIDOHYDRO-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.42"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03742"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03743"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36728,6 +37464,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5293"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.16"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.24"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08324"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00135"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00139"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17761"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36762,6 +37502,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97524"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-884"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.17.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03527"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36828,6 +37569,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100024"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTAMINESYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01915"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36864,6 +37606,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100946"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:KYNURENINASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.7.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01556"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -36932,6 +37675,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101037"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DLACTDEHYDROGNAD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.28"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03778"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03777"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37001,6 +37746,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR140148"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RIBOKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.15"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00852"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37131,6 +37877,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CATAL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.11.1.6"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.11.1.21"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03781"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37177,6 +37924,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141999"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:H2PTERIDINEPYROPHOSPHOKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.6.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00950"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07142"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13941"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13939"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37212,8 +37964,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94941"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9528"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.100"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00059"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11539"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37248,6 +38003,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.3.2.10"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02500"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01663"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02501"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37342,6 +38100,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.7"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15780"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19836"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00769"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00760"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03816"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37374,6 +38137,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95745"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-10089"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00149"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00128"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37466,8 +38232,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94952"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9518"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.100"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00059"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11539"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37500,6 +38269,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97898"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PGLUCONDEHYDRAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01690"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37530,6 +38300,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99668"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:5-FORMYL-THF-CYCLO-LIGASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.3.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00603"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01934"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37563,6 +38335,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-2382"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.20"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.122"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01696"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01695"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37599,6 +38374,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108987"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SAICARSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01923"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01587"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13713"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37697,6 +38475,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DEOXYGLUCONOKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.45"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.178"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00874"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18126"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37759,6 +38539,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/30850"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100293"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00252"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37796,6 +38577,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03239"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108041"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00850"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16370"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37828,6 +38611,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104083"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RIBULP3EPIM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.1.3.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01783"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37857,6 +38641,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141683"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8991"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.33"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01703"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01702"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21359"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01704"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37888,6 +38676,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100878"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-ISOPROPYLMALDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.85"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21360"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00052"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -37924,6 +38714,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.42"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01510"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12304"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14642"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12305"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38022,6 +38818,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12558"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.8.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.44"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00209"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38058,6 +38855,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.222"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13788"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00625"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15024"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13923"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38088,6 +38889,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106847"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HISTALDEHYD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.23"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00013"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14152"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38152,6 +38955,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105142"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:URACIL-PRIBOSYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00761"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38217,6 +39022,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101980"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:QUINOPRIBOTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00767"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38252,8 +39058,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101421"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MALONYL-COA-ACP-TRANSACYL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.39"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13935"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00645"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38430,6 +39239,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12445"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.41"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.30"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05901"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05368"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38462,11 +39273,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04355"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100912"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-OXOACYL-ACP-SYNTH-BASE-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.41"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.180"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00647"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09458"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38540,6 +39353,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/19912"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138959"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.2.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00101"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38591,6 +39405,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.1.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.1.25"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.20"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00691"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09844"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38619,6 +39435,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R05030"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100253"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.5.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07009"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23393"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38681,6 +39499,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100736"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HOMOSERINE-O-ACETYLTRANSFERASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.31"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00651"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19726"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38711,6 +39532,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:6.3.4.16-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.16-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01948"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38780,6 +39602,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96321"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:325-BISPHOSPHATE-NUCLEOTIDASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06881"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07053"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15422"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15759"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01082"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38811,6 +39638,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97364"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.7.1.121-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.121"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05879"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05881"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05878"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38842,6 +39672,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HOLO-ACP-SYNTH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06133"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00997"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02362"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38906,6 +39739,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.1.1.8-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.94"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00006"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00057"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38935,6 +39770,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111210"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142264"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -38970,6 +39808,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101938"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DUDPKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39003,6 +39843,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141984"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDP-NACMUR-ALA-LIG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01924"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39023,7 +39864,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14140"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn00872_c0" sboTerm="SBO:0000176" id="R_rxn00872_c0" name="Butanoyl-CoA:oxygen 2-oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn00872_c0" sboTerm="SBO:0000176" id="R_rxn00872_c0" name="Butanoyl-CoA:oxygen 2-oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn00872_c0">
@@ -39041,6 +39882,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.8.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00248"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00232"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00249"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09478"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06445"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39087,6 +39933,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:IMPCYCLOHYDROLASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.2.3"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11176"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00602"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39114,6 +39962,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96322"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:R163-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15759"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01082"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06881"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15422"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39151,6 +40003,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.2.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.2.11"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.2.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15633"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15635"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01834"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01837"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15634"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39218,6 +40075,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R06142"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97918"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07407"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01189"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39252,6 +40112,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139030"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PYRROLINECARBREDUCT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00286"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39317,6 +40178,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97453"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DHSHIKIMATE-DEHYDRO-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.118"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26400"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15652"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09483"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39507,6 +40371,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95645"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-743"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.99.18"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01588"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39538,6 +40403,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96945"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CTPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01937"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39573,6 +40439,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107368"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ILEDEAMINE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00263"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39612,6 +40479,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.4.13.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.4.11.23"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.4.13.18"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11142"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15428"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01270"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01255"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01256"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11140"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39646,6 +40520,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04620"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139295"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01113"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01077"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39721,6 +40597,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139064"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.6.99.7"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.34"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00357"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39753,6 +40630,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101941"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14120"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39816,6 +40695,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/31134"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139269"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.2.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01492"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00601"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11175"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11787"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39852,6 +40735,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR134508"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIHYDROXYMETVALDEHYDRAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01687"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39883,6 +40767,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96118"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DGDPKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -39980,6 +40866,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-10949"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-10952"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10047"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18649"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01092"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40013,6 +40902,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12490"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.35"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.211"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07516"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40081,6 +40975,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99875"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.99.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.5.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00111"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00113"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00112"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40141,6 +41038,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138654"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:FORMIMINOGLUTAMASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.3.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01479"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40177,6 +41075,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142219"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDPHYDROXYMYRGLUCOSAMNACETYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.191"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02536"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40208,6 +41107,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97141"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIAMINOPIMDECARB-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.20"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01586"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12526"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40237,6 +41138,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04224"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138263"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40271,6 +41178,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/32718"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106779"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.85"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00052"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40307,6 +41215,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.21"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.53"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01517"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08312"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26956"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13988"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18453"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13987"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40343,6 +41258,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95198"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-13617"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07508"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00632"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40381,6 +41300,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101096"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LEUCINE-DEHYDROGENASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00263"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40416,6 +41336,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138514"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00844"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00847"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40447,6 +41369,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-2044"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.35"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.157"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00074"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00022"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40549,7 +41476,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109249"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9659"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00208"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02371"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40583,6 +41513,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-3341"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.343"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.44"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00033"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40616,6 +41547,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:URUR-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.3.26"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.3.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14977"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40712,6 +41644,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:4.1.3.26-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.26"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01640"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40743,6 +41676,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95806"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DAPASYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.62"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00833"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19562"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40774,6 +41709,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SUCCGLUALDDEHYD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.71"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06447"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40808,6 +41744,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103139"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYRIBONUCSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13713"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01945"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11788"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11787"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40842,6 +41782,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97894"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TIGLYLCOA-HYDROXY-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40914,6 +41860,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.5.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.5.4"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01425"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01954"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01956"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23265"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01955"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -40978,6 +41932,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103156"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PRAISOM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.24"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13498"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13501"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01817"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24017"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41019,6 +41977,16 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALCOHOL-DEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.71"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00121"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13954"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13980"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04072"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13951"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18857"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13952"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13953"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41086,6 +42054,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PSERPHOSPHA-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5114"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02203"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01079"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25528"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22305"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41318,6 +42290,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99706"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:FUMARYLACETOACETASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.7.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16171"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01555"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41339,7 +42313,7 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn00469_c0" sboTerm="SBO:0000176" id="R_rxn00469_c0" name="N2-Acetyl-L-ornithine amidohydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn00469_c0" sboTerm="SBO:0000176" id="R_rxn00469_c0" name="N2-Acetyl-L-ornithine amidohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn00469_c0">
@@ -41352,6 +42326,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETYLORNDEACET-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.16"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.14"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14677"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01438"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41414,6 +42390,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-16560"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.16"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.155"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07508"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00632"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41511,6 +42491,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102495"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ERYTHRON4PDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.290"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03473"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41545,6 +42526,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103430"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RIBOFLAVIN-SYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00793"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41576,6 +42558,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96800"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:N-CARBAMOYLPUTRESCINE-AMIDASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.53"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12251"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41610,6 +42593,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/28036"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104060"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.17.4.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00525"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10808"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00526"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10807"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41672,6 +42659,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95693"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALARACECAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.1.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01798"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01775"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41756,6 +42745,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00985"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95844"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.27"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13497"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01658"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01657"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13503"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13501"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01656"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41796,6 +42791,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTDEHYD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.3"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00262"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00266"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00265"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00261"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41840,6 +42839,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104240"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SULFATE-ADENYLYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00958"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00956"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00957"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00955"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13811"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41909,9 +42913,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR122848"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9520"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.59"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.58"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16363"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01716"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02372"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41950,6 +42959,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NICONUCADENYLYLTRAN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.18"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19785"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13522"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00952"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06211"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06210"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -41992,7 +43007,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19365"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn02866_c0" sboTerm="SBO:0000176" id="R_rxn02866_c0" name="3-methylbutanoyl-CoA:(acceptor) 2,3-oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn02866_c0" sboTerm="SBO:0000176" id="R_rxn02866_c0" name="3-methylbutanoyl-CoA:(acceptor) 2,3-oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn02866_c0">
@@ -42006,6 +43021,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.3"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.8.4"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00253"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00249"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42035,6 +43052,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/30298"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100460"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.40"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00873"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42127,6 +43146,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97435"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RIBOFLAVINSYNDEAM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.26"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01498"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11752"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42156,8 +43177,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04533"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94951"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.100"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00059"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11539"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42183,7 +43207,8 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05460"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR134955"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.0"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.41"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42276,6 +43301,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103045"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PYRIMSYN3-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21219"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00941"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00877"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14153"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42331,6 +43360,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138680"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.2.1.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.2.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01895"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01908"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42364,6 +43395,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96080"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ASPCARBTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.3.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00608"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00610"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00609"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42393,6 +43429,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141855"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106766"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26955"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01518"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42561,6 +43599,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9623"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-7904"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.2.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01897"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K28161"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15013"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42600,6 +43641,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97888"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.74"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13767"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42662,6 +43711,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95687"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALANINE-DEHYDROGENASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00259"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19244"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42700,6 +43751,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102539"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:6PGLUCONOLACT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.1.31"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13937"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07404"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01057"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42740,6 +43794,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100446"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTATHIONE-PEROXIDASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.11.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00432"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42778,6 +43833,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142041"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDPACYLGLCNACDEACETYL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.108"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02535"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16363"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42810,6 +43867,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:4OHBENZOATE-OCTAPRENYLTRANSFER-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.39"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03179"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42843,6 +43901,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR132709"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-ISOPROPYLMALISOM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.33"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01703"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01702"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21359"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01704"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42900,6 +43962,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95136"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETOACETATE--COA-LIGASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.2.1.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01907"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42942,6 +44005,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96944"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14325"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01937"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -42978,6 +44042,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104715"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANSALDOL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.2.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00616"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13810"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43038,6 +44104,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142209"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108654"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43071,6 +44138,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103050"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PANTOTHENATE-KIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.33"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09680"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01947"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00867"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03525"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43103,6 +44174,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12197"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01510"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12304"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14642"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12305"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43133,6 +44210,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/23195"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105036"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.1.227"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02563"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43163,8 +44241,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94944"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9536"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.100"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00059"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11539"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43228,6 +44309,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96485"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CARBPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.5.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01954"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01956"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01955"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43332,6 +44418,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MALIC-NAD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.38"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.39"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00027"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00028"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43363,11 +44451,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01624"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95376"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACP-S-ACETYLTRANSFER-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.38"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.180"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43402,6 +44489,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100457"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GTPPYPHOSKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.6.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00951"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07816"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01139"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43439,6 +44529,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99705"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:FUMHYDR-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01678"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01677"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01675"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01774"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01676"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01679"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43504,6 +44600,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14160"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.4.2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.4.46"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18696"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18695"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01126"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43538,6 +44637,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108111"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPM-KDOSYNTH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.38"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00979"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43572,6 +44672,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.2.1.6"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00161"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00163"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11258"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01653"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01568"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00162"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01652"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43608,6 +44715,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142259"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101693"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43683,6 +44793,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THRESYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.3.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.99.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01733"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43714,6 +44825,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95842"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PRTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.18"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00766"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13497"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43747,6 +44860,21 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95444"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ADENYLATECYC-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.6.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08049"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11029"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08046"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11265"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01768"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05851"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08045"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22944"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08044"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08041"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08043"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08048"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08042"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08047"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05873"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43783,6 +44911,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.48"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.213"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22026"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00876"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21057"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43851,6 +44982,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94843"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:4-HYDROXYPHENYLPYRUVATE-DIOXYGENASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.13.11.27"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00457"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -43883,6 +45015,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97201"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DCTP-DEAM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01494"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44026,6 +45159,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.7.7.1-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.18"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19785"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13522"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00952"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06211"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06210"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44058,6 +45197,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95200"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14274"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07508"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00632"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44095,6 +45238,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/30662"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95024"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.3.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01733"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44129,6 +45273,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100734"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HOMOSERDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00003"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12525"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12524"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44218,6 +45365,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138045"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALTRODEHYDRAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01685"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16849"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16850"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44309,6 +45459,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:4OH2OXOGLUTARALDOL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.42"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01625"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18123"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44346,6 +45498,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDPNACETYLMURAMATEDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.98"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.158"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00075"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44381,6 +45534,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96880"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-1461"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.3.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00228"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44493,6 +45647,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04391"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95866"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.33"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09680"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01947"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00867"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03525"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44526,6 +45684,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101411"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:METHYLCROTONYL-COA-CARBOXYLASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.4.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01968"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44562,6 +45722,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/12359"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138575"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01809"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15916"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16011"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44709,6 +45872,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139017"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:FORMYLTHFDEFORMYL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01433"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44809,6 +45973,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102148"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXNI-2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01027"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01029"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01028"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44842,6 +46009,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96807"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.7.7.60-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.60"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00991"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12506"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44874,6 +46043,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR126494"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141961"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.15"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00852"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44908,6 +46078,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139237"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HISTPRATPHYD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.31"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01523"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11755"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14152"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44944,6 +46117,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97932"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2PGADEHYDRAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K27394"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01689"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -44974,6 +46149,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105150"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UROCANATE-HYDRATASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.49"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01712"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45003,6 +46179,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106802"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PRPPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.6.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00948"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45067,6 +46244,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/32250"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139065"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.34"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00357"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45137,6 +46315,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NADPYROPHOSPHAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.22"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03426"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04765"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26956"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45231,10 +46413,10 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn06377_c0" sboTerm="SBO:0000176" id="R_rxn06377_c0" name="glycine:lipoylprotein oxidoreductase (decarboxylating and acceptor-aminomethylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn09499_c0" sboTerm="SBO:0000176" id="R_rxn09499_c0" name="glycine:lipoylprotein oxidoreductase (decarboxylating and acceptor-aminomethylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn06377_c0">
+            <rdf:Description rdf:about="#meta_R_rxn09499_c0">
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn06377"/>
@@ -45243,6 +46425,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03425"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100067"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.4.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00281"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00282"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00283"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45332,6 +46517,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99133"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9624"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.2.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01068"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17360"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45367,6 +46554,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95413"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETATE--COA-LIGASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.2.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01895"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01913"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45458,6 +46647,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104885"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THYKI-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.21"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00857"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05961"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45525,6 +46716,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ASPAMINOTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-13697"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11358"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14455"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14454"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00813"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00811"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00812"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45591,6 +46788,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.3.6"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00232"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00249"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06445"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09479"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00255"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45634,6 +46836,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105032"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDPNACETYLGLUCOSAMENOLPYRTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00790"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45670,6 +46873,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97317"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALPHAGALACTOSID-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07407"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01189"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45701,6 +46907,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106752"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PROPANOATECOA-LIGASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.2.1.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24012"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01905"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22224"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45773,6 +46982,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108966"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:AICARSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.3.2.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01756"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45804,6 +47014,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141833"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.21"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.74"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05349"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01188"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05350"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45895,6 +47108,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR140860"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8813"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.81"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K28131"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45926,6 +47140,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01899"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105340"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.42"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00031"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -45957,6 +47172,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01103"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103419"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07407"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01189"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46019,6 +47237,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139261"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:AIRS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.3.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01933"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11788"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11787"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46086,6 +47307,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99614"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-6321"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.2.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00605"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46121,6 +47343,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12618"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.2.2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.4.19.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00681"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18592"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46158,6 +47382,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139287"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:AICARTRANSFORM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.2.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00602"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01492"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46195,6 +47421,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:6PGLUCONDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.44"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.351"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00033"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46221,7 +47448,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05462"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR134957"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.0"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.59"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46287,6 +47514,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96232"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-HYDROXYBUTYRATE-DEHYDROGENASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.30"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00019"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46373,6 +47601,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02021"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102376"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.4.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00390"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46445,6 +47674,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETYLHOMOSER-CYS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.49"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.99.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01740"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46481,6 +47711,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101443"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MALIC-NADP-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.40"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00029"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46516,6 +47747,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102029"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:XMPXAN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46559,6 +47796,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14122"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.4"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00943"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46595,6 +47833,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.2.1.2-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.17.1.9"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00127"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00124"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00122"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22515"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00123"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00126"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46683,6 +47927,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR112349"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLCNACPTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.33"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02851"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46770,6 +48015,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/16086"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:6.3.2.10-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01798"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01929"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46867,6 +48114,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25589"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01239"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46897,12 +48146,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR122851"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94877"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9533"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.60"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.59"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.58"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.61"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16363"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01716"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02372"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46938,6 +48190,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CYTIDEAM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.14"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01489"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -46973,6 +48226,22 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95219"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETYL-COA-CARBOXYLTRANSFER-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.4.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15036"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18472"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15037"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01946"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11262"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11263"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01962"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18605"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22568"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18604"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02160"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18603"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19312"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01963"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01964"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01961"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47039,6 +48308,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103226"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.5.1.19-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13830"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00800"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24018"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47075,6 +48347,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101937"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DTDPKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47106,6 +48380,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95436"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ADCLY-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.38"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18482"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02619"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03342"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47137,6 +48414,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142121"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.5.1.20-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.20"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00297"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24042"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25009"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47170,6 +48450,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LAUROYLACYLTRAN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.241"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02517"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47236,6 +48517,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12570"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.35"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.211"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07516"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47272,6 +48560,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100810"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ISPH2-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.17.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03527"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47310,6 +48599,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:METHYLACETOACETYLCOATHIOL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.16"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07508"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00632"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47345,6 +48638,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105163"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:URKI-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.48"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00876"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47377,6 +48671,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95440"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PABASYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.85"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01664"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13950"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03342"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47447,6 +48745,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PALMITOYL-COA-HYDROLASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.2.2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.2.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01074"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10805"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10806"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10804"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01068"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17360"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47481,6 +48785,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:BRANCHED-CHAINAMINOTRANSFERVAL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.6"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.42"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00826"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47512,6 +48817,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102543"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GPH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.18"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22223"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19269"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01091"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47546,6 +48854,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99561"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-1483"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.16.3.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22552"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03594"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22336"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13624"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13625"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18495"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14735"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00522"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19054"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47581,6 +48898,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95628"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12625"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.52"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12373"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01207"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47620,6 +48939,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97449"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-DEHYDROQUINATE-DEHYDRATASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13830"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13832"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03785"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03786"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47687,6 +49010,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTATHIONE-REDUCT-NADPH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.1.7"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.6.4.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00383"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47717,6 +49041,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/20276"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139508"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.14.16.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00500"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47781,6 +49106,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DEOXYADENYLATE-KINASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.11"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18532"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00939"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47875,6 +49203,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100348"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYCEROL-KIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.30"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00864"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47907,6 +49236,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102063"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6377"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17877"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26138"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26139"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00361"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47941,8 +49274,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04536"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94953"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.100"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00059"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11539"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -47975,6 +49311,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102201"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-OCTAPRENYL-4-OHBENZOATE-DECARBOX-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03186"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03182"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48072,6 +49410,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.6.1.3"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.6.1.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.6.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00322"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48109,6 +49448,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104362"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SUCCGLUDESUCC-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.96"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05526"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48229,6 +49569,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02454"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101389"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.57"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00040"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48259,6 +49600,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/11923"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR122085"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.96"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01724"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48291,6 +49633,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12565"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.16"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00626"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07508"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00632"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48335,6 +49682,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100830"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:IMP-DEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.205"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00088"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48370,6 +49718,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GAPDHSYNEC-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.13"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.59"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00150"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05298"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48402,6 +49752,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106560"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14065"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06966"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48440,6 +49791,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:5.4.2.5-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.2.2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.2.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15778"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01835"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15779"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48467,6 +49821,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94991"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14209"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00149"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00128"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48669,6 +50026,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DAHPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.15"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.54"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03856"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13853"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01626"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48730,6 +50090,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/27629"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138866"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.2.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00615"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48769,6 +50130,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139019"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HOMOCYSMETB12-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.1.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00548"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24042"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48806,6 +50169,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-385"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25500"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48838,6 +50202,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97831"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DXS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.2.1.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01662"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48873,6 +50238,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR132639"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PGLYCDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.95"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00058"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48910,6 +50276,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138471"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UTPHEXPURIDYLYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12447"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48942,6 +50309,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108904"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:FGAMSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.5.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23265"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01952"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23270"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23269"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23264"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -48981,6 +50353,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.15"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01529"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01510"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14642"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49028,10 +50404,10 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01930"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn06600_c0" sboTerm="SBO:0000176" id="R_rxn06600_c0" name="S-aminomethyldihydrolipoylprotein:(6S)-tetrahydrofolate aminomethyltransferase (ammonia-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn09498_c0" sboTerm="SBO:0000176" id="R_rxn09498_c0" name="S-aminomethyldihydrolipoylprotein:(6S)-tetrahydrofolate aminomethyltransferase (ammonia-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn06600_c0">
+            <rdf:Description rdf:about="#meta_R_rxn09498_c0">
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn06600"/>
@@ -49042,6 +50418,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139249"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142211"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.2.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00605"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49078,6 +50455,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101684"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:KDOTRANS2-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.99.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02527"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49114,6 +50492,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUCOKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25026"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00844"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12407"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00845"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49179,6 +50561,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00771"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138699"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15916"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13810"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01810"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06859"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49284,6 +50670,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95942"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTDECARBOX-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.15"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01580"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49321,6 +50708,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.6"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.67"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.42"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00826"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49348,7 +50736,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04969"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109258"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00208"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02371"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49413,6 +50804,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.3"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00137"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00149"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12254"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00128"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49456,6 +50852,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.4"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00129"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00138"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49523,7 +50921,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04966"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109255"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00208"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02371"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49624,6 +51025,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102036"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14161"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07023"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06952"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08722"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49666,6 +51076,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97779"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2-DEHYDROPANTOATE-REDUCT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.169"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00077"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24263"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49739,6 +51151,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101882"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NAD-KIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.23"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00858"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49769,6 +51182,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/22147"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95387"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K27802"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01681"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01682"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49806,6 +51222,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138455"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.3.1.157-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.157"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04042"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23144"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49898,6 +51316,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104375"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SIROHEME-FERROCHELAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.99.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02304"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02302"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03794"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49932,6 +51353,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103402"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THREODEHYD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.103"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00060"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15789"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49966,6 +51389,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97180"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DETHIOBIOTIN-SYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.3.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19562"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01935"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -49999,6 +51424,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109369"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.5.1.80-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02079"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50058,6 +51484,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R06152"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100010"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07407"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01189"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50089,6 +51518,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106950"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HYDROXYMETHYLGLUTARYL-COA-LYASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01640"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50146,6 +51576,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100546"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.35"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.211"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07516"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50169,7 +51606,7 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn01924_c0" sboTerm="SBO:0000176" id="R_rxn01924_c0" name="isobutyryl-CoA dehydrogenase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn01924_c0" sboTerm="SBO:0000176" id="R_rxn01924_c0" name="isobutyryl-CoA dehydrogenase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn01924_c0">
@@ -50214,6 +51651,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97039"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CYTIDEAM2-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01489"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50276,6 +51714,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95678"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DALADALALIG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01921"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50342,6 +51781,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.6.1.19-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04765"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01513"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50401,6 +51842,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/28033"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104062"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.17.4.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00525"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10808"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00526"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10807"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50472,6 +51917,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138021"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ADENOSYLHOMOCYSTEINASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.3.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01251"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50504,6 +51950,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139139"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DTDPDEHYRHAMREDUCT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.133"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23987"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00067"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50534,6 +51982,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107105"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1TRANSKETO-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.2.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00615"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50570,6 +52019,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104357"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:S-FORMYLGLUTATHIONE-HYDROLASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.2.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01070"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50636,6 +52086,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-18331"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIHYDLIPOXN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00382"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50664,9 +52115,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/3HAD160"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04544"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94881"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.61"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.59"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16363"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01716"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02372"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50702,6 +52159,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104907"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THI-P-KIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00946"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50778,6 +52236,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.21"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.72"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00011"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50843,6 +52302,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138478"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100115"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07407"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01189"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50880,6 +52342,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/20871"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95163"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.28"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22934"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01194"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50945,6 +52409,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100813"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:IMIDPHOSDEHYD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01089"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01693"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -50976,6 +52442,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100390"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUCONOKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00851"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25031"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51006,6 +52474,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/24051"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138992"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.1.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00690"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51063,6 +52532,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95949"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ARGSUCCINSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01940"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51098,6 +52568,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141870"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.2.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00606"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51190,6 +52661,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03276"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108069"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.1.2.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51255,6 +52728,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95501"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:FADSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00953"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11753"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14656"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22949"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51315,6 +52792,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/28041"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104064"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.17.4.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00525"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10808"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00526"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10807"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51435,6 +52916,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/31106"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97400"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19644"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18590"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18591"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18589"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00287"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13998"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19643"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51471,6 +52959,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR134439"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100904"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00053"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51509,6 +52998,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101580"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:4.2.1.99-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.99"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K27802"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01682"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51540,6 +53031,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SUCCARGDIHYDRO-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.3.23"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.69"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01484"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51571,11 +53063,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/MCMAT7"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04968"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109257"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.41"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.180"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00647"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09458"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51612,6 +53106,14 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97891"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.74"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13767"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51650,6 +53152,17 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102028"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14143"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08723"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01081"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07023"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11751"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25434"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06952"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08722"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19970"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51724,6 +53237,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109272"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2-OCTAPRENYLPHENOL-HYDROX-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.14.13.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18800"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51758,6 +53272,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95788"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-4281"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08325"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51826,6 +53341,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101325"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MALEYLACETOACETATE-ISOMERASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.2.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01800"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51858,6 +53374,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96094"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:L-ASPARTATE-OXID-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.3.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00278"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51890,6 +53407,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99896"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTSEMIALDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.41"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00147"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12657"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51923,6 +53442,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102198"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-13458"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.80"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18364"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02554"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51953,6 +53474,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95816"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:R311-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01426"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -51985,6 +53507,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100291"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTAMATESYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00266"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00265"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52032,6 +53556,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.14"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.22"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13809"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13800"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09903"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52063,6 +53590,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139204"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:R524-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.104"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01725"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52096,6 +53624,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105162"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:URIDINEKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.48"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00876"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52125,6 +53654,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101698"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142261"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52186,6 +53718,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.6.1.19-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ATP-PYROPHOSPHATASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04765"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01513"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52217,6 +53751,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100652"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.5.2.17-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.2.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19964"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07127"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13484"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52281,6 +53818,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99634"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:FPPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00804"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00795"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13789"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13787"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52372,6 +53914,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100741"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HOMSUCTRAN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.46"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00651"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52462,6 +54006,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACONITATEDEHYDR-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.3"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K27802"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01681"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01682"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52499,6 +54046,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138900"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDP-NACMURALA-GLU-LIG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01925"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52588,6 +54136,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142080"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PHOSNACMURPENTATRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01000"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52620,6 +54169,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100464"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GUANINE-DEAMINASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01487"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52710,6 +54260,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105140"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UROGENDECARBOX-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.37"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01599"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52771,6 +54322,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NUCLEOSIDE-DIP-KIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CDPKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52930,6 +54483,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/30730"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97145"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.40"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00873"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52964,6 +54519,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PANTETHEINE-KINASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.33"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.34"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09680"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01947"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00867"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03525"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -52997,6 +54556,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-1602"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01519"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53030,6 +54590,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109723"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UNDECAPRENYL-DIPHOSPHATASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.27"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06153"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19302"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53061,6 +54623,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01092"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99985"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00849"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53094,6 +54657,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107497"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALLANTOATE-DEIMINASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.3.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02083"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53155,6 +54719,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.8.9"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00232"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00249"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06445"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09479"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00255"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53196,6 +54765,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101934"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14228"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53226,7 +54797,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109246"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9658"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00208"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02371"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53293,6 +54867,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111053"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-742"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.18"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01589"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53330,6 +54905,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.5"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.3"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00149"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00129"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00128"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53367,6 +54946,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDP-NACMURALGLDAPAALIG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.15"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01798"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15792"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01929"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53403,6 +54985,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.8.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00248"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00232"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00249"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09478"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06445"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00255"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53450,6 +55038,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102303"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PYRROLINECARBREDUCT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00286"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53518,6 +55107,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.41"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01101"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53561,6 +55151,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ASPARAGHYD-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.38"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05597"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01424"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13051"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53602,6 +55195,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.7"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.3.16"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.3.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K27797"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01647"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05942"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01659"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53667,6 +55264,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139268"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GART-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.2.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01492"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00601"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11175"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11787"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53730,6 +55331,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NAD-SYNTH-NH3-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.5.1"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.1.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01916"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53792,6 +55394,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105028"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDPNACETYLGLUCOSAMACYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.129"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00677"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53843,7 +55446,7 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn02167_c0" sboTerm="SBO:0000176" id="R_rxn02167_c0" name="(S)-3-Hydroxybutanoyl-CoA hydro-lyase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn02167_c0" sboTerm="SBO:0000176" id="R_rxn02167_c0" name="(S)-3-Hydroxybutanoyl-CoA hydro-lyase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn02167_c0">
@@ -53859,6 +55462,16 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.55"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13767"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15016"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01715"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53896,6 +55509,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97076"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ADDALT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19572"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01488"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -53933,6 +55548,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96697"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-6021"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11440"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54063,6 +55679,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95854"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:7KAPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.47"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00652"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54095,6 +55712,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR106651"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11632"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13821"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00294"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54163,6 +55782,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102526"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:5.4.2.10-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.2.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K28126"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03431"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54257,6 +55878,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138858"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TETHYDPICSUCC-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.117"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00674"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54348,6 +55970,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100144"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GUANYL-KIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00942"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54376,6 +55999,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00621"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105310"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00164"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01616"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54404,6 +56029,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00428"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138935"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22391"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09007"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01495"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54438,6 +56066,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.74"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07511"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54475,6 +56110,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95530"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:N-ACETYLGLUTPREDUCT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.38"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K12659"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00145"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54509,6 +56146,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95814"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXNN-404"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01426"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21801"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54538,6 +56177,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02926"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101463"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07407"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01189"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54568,6 +56210,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105170"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LIPIDXSYNTHESIS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.54"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03269"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09949"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54606,6 +56250,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102345"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PANTOATE-BETA-ALANINE-LIG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01918"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13799"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54641,6 +56287,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-13198"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.202"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13921"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00086"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54681,6 +56329,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14116"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.12"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.88"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13821"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00294"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54724,6 +56374,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SULFITE-REDUCT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.2.2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00385"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16950"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00380"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16951"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54841,6 +56496,12 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95161"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11737"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11358"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14455"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14454"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00813"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00811"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00812"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54876,6 +56537,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101729"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PHOSMANMUT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.4.2.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16881"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15778"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01840"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17497"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54940,6 +56605,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95786"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALLOPHANATE-HYDROLASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.54"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01457"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -54974,6 +56641,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100814"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:IGPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.48"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13498"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01609"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13501"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01656"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55035,6 +56706,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135723"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETOOHBUTSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.2.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01653"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11258"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01652"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55070,6 +56744,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95529"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:AGMATINE-DEIMINASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.3.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10536"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55245,6 +56920,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104343"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRYPSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.20"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01696"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01695"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01694"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55318,6 +56997,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141985"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:P-PANTOCYSDECARB-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.36"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01598"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13038"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55349,6 +57030,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95432"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ADENODEAMIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19572"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05810"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01488"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55386,6 +57070,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101683"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:KDOTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.99.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02527"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55448,6 +57133,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100468"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR115923"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01812"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55542,6 +57228,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR140843"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.13.11.11"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.13.11.52"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00453"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00463"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55605,6 +57293,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PROTOHEMEFERROCHELAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6258"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.99.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01772"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55640,6 +57329,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.12"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.13"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00943"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55669,11 +57359,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/3HAD100"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04535"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94876"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.60"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.58"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.61"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.59"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22541"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16363"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01716"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02372"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55709,6 +57403,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95201"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14268"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.16"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07508"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00632"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55743,6 +57441,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03051"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107913"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00053"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55808,6 +57507,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102438"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PNPOXI-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.3.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23998"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00275"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55843,6 +57544,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100353"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYOXII-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.2.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01069"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55876,6 +57578,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95898"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RIBOFLAVINSYNREDUC-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.193"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00082"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11752"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55908,6 +57612,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100544"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.35"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.211"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01825"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01782"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07514"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07516"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07515"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55946,6 +57657,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102247"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-OXOADIPATE-ENOL-LACTONASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.1.24"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14727"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01055"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -55985,6 +57698,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLU6PDEHYDROG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.363"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.49"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00036"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56054,6 +57768,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100313"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:AKBLIG-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.29"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00639"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56111,6 +57826,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PROPIONATE--COA-LIGASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.2.1.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.2.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01895"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01908"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56236,6 +57953,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-13482"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ORNCARBAMTRANSFER-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.3.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00611"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56265,6 +57983,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135216"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108002"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56364,6 +58083,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CYCLOHEXADIENYL-DEHYDROGENASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.43"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.79"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00220"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24018"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56516,6 +58237,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103225"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PSERTRANSAM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.52"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00831"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56550,6 +58272,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIHYDROFOLATESYNTH-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.17"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01930"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11754"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24102"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22099"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K20457"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56584,6 +58311,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUCOSE-1-DEHYDROGENASE-NADP+-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.119"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.360"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18125"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18124"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56621,6 +58350,15 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-19329"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIHYDROFOLATEREDUCT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19644"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18590"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18591"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18589"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13938"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00287"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13998"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19643"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19645"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56714,6 +58452,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/28028"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104066"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.17.4.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00525"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10808"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00526"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10807"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56749,6 +58491,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00942"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139015"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.2.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01930"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11754"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22099"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56813,6 +58558,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141907"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYCERALDEHYDE-DEHYDRO-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00149"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00128"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56835,7 +58583,7 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn05289_c0" sboTerm="SBO:0000176" id="R_rxn05289_c0" name="NADPH:oxidized-thioredoxin oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn05289_c0" sboTerm="SBO:0000176" id="R_rxn05289_c0" name="NADPH:oxidized-thioredoxin oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_rxn05289_c0">
@@ -56849,6 +58597,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104766"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.8.1.9"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.6.4.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00384"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56883,6 +58632,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104300"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SUCCDIAMINOPIMDESUCC-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.18"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01439"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56926,6 +58676,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NUCLEOSIDE-DIP-KIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:UDPKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -56957,11 +58709,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04960"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109251"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9527"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.85"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.86"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.41"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.180"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.179"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00647"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09458"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57000,6 +58754,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141921"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THYMIDYLATESYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.1.45"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00560"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13998"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57031,6 +58787,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102170"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2-OCTAPRENYL-6-OHPHENOL-METHY-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.1.222"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00568"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57076,6 +58833,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MALSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.3.9"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01638"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57147,6 +58905,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/16576"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102169"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.52"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00831"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57175,6 +58934,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/32278"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109874"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.262"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00097"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57209,6 +58969,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-366"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.8"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01239"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57246,6 +59007,18 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.57"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.58"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11358"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00817"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K05821"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14455"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00832"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14454"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00813"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00811"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15849"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00815"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00838"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00812"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57313,6 +59086,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100355"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYOXI-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.4.1.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01759"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57350,6 +59124,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.7.7.64-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NAG1P-URIDYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.23"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04042"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K23144"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11528"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00972"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57416,6 +59194,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105090"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GALACTURIDYLYLTRANS-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00965"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57450,6 +59229,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.65"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.1.8"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K08320"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K04765"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06287"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K25435"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01513"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57512,6 +59296,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101940"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DADPKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.4.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18533"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57540,6 +59326,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R06096"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101747"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07407"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07406"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01189"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57598,6 +59387,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR103041"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11483"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.1.85"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19561"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02170"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19560"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09789"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57615,13 +59408,13 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19215"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn14159_c0" sboTerm="SBO:0000176" id="R_rxn14159_c0" name="Ferredoxin:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn05937_c0" sboTerm="SBO:0000176" id="R_rxn05937_c0" name="Ferredoxin:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn14159_c0">
+            <rdf:Description rdf:about="#meta_R_rxn05937_c0">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn14159"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05937"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01195"/>
                   <rdf:li rdf:resource="https://identifiers.org/rhea/20128"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99609"/>
@@ -57672,15 +59465,17 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10785"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn27289_c0" sboTerm="SBO:0000176" id="R_rxn27289_c0" name="thiazole synthase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_thiazol_synth" sboTerm="SBO:0000176" id="R_thiazol_synth" name="thiazole synthase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn27289_c0">
+            <rdf:Description rdf:about="#meta_R_thiazol_synth">
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn27289"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR123908"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:THIAZOLSYN2-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.73"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.10"/>
                 </rdf:Bag>
               </bqbiol:is>
@@ -57743,6 +59538,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07639"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111240"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.3.14"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01716"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18474"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57892,6 +59689,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR114031"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12610"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14153"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21219"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00788"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14154"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21220"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -57926,6 +59728,9 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETOLACTSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.3.18"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.2.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01653"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11258"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01652"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -58034,6 +59839,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:O-SUCCHOMOSERLYASE-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.99.9"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.48"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01739"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -58128,6 +59934,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97523"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETOLACTREDUCTOISOM-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.86"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00053"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -58158,6 +59965,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05121"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07412"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100591"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02259"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -58943,6 +60751,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139727"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8348"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.10.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03750"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15376"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59001,6 +60811,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR113172"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11328"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11211"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59034,6 +60845,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11564"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.96"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13747"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59122,6 +60934,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95855"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11484"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.47"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00652"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59235,6 +61048,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR114019"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14930"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.105"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19563"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59322,6 +61136,10 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/26302"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-6201"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.1.97"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16838"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13484"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13485"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16840"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59406,6 +61224,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135611"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-4022"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.1.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09457"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06879"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59435,6 +61255,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR113371"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6451"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.110"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09020"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59467,6 +61288,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6460"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.110"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09020"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59498,6 +61320,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR113333"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6444"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.14.99.46"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09024"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09018"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59528,6 +61352,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR94854"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6452"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09023"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59585,6 +61410,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn15296"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02036"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01690"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59610,6 +61436,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn15293"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01983"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.1.12"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01812"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59636,6 +61463,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/rhea/13556"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GALACTOKIN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00849"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59751,6 +61579,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102153"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8992"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.90"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02523"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59863,6 +61692,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03494"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108209"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.4.1.5"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13778"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13777"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -59983,6 +61814,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn40368"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R10619"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR113944"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01785"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -60069,6 +61901,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97358"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DIHYDROXYISOVALDEHYDRAT-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.2.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01687"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -60127,6 +61960,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96492"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12093"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/6.3.4.20"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06920"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -60160,6 +61994,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96522"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6575"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.3.99.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10026"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -60190,6 +62025,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95095"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5507"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.50"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01737"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -60421,6 +62257,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03472"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PYRIMSYN1-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.99.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03147"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -60456,6 +62293,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11566"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.43"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13746"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -60546,6 +62384,11 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8974"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.298"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15039"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18602"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K16066"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09019"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14468"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -60580,6 +62423,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142130"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HEMEOSYN-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02257"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -60611,6 +62455,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn16828"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09982"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR113373"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09021"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -60639,6 +62484,8 @@
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DHDOGALDOL-RXN"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.-"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.1.2.51"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11395"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18127"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -61139,6 +62986,7 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR99239"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-2961"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/4.4.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03396"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -61700,6 +63548,13 @@
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.4.2"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.4.12"/>
                   <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.3.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06928"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01510"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06857"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15497"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14642"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01509"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -62181,6 +64036,585 @@
         <listOfReactants>
           <speciesReference species="M_cpd02701_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_rxn09008_c0" sboTerm="SBO:0000655" id="R_rxn09008_c0" name="nitric oxide transport via diffusion (extracellular to periplasm) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn09008_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NOt"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NOtpp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NOtd"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NOtex"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR125235"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09008"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_FeS_cluster_biosynth" sboTerm="SBO:0000176" id="R_FeS_cluster_biosynth" name="[4Fe4S] iron-sulfur cluster biosynthesis" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12865"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn08013_c0" sboTerm="SBO:0000176" id="R_rxn08013_c0" name="5&apos;-deoxyadenosine ribohydrolase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn08013_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/5DOAN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.2.2.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R12621"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR152703"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08013"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14795"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_cpd15380_transport" sboTerm="SBO:0000176" id="R_cpd15380_transport" name="5&apos;-deoxyribose transport by diffusion" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_cpd15380_transport">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DRIBtex_1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142736"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn06591_c0" sboTerm="SBO:0000176" id="R_rxn06591_c0" name="L-glutamate-semialdehyde: NADP+ oxidoreductase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn06591_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUTRR"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.70"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02492"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04109"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR145079"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn06591"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06865"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn02304_c0" sboTerm="SBO:0000176" id="R_rxn02304_c0" name="Protoporphyrinogen-IX:oxygen oxidoreductase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn02304_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PPPGOm"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PROTOPORGENOXI-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.3.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00231"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03222"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR146109"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02304"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_fe3_reduction" sboTerm="SBO:0000176" id="R_fe3_reduction" name="Reduction of Fe3+ by bacterioferritin-associated ferredoxin" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction metaid="meta_R_rxn01213_c0" sboTerm="SBO:0000176" id="R_rxn01213_c0" name="Geranyl diphosphate synthase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01213_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DMATT"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GPPSYN-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.5.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00804"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00795"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14066"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13789"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K13787"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01658"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97512"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01213"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn03087_c0" sboTerm="SBO:0000176" id="R_rxn03087_c0" name="N-Succinyl-L-2,6-diaminoheptanedioate:2-oxoglutarate amino-transferase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn03087_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/SDPTA"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SUCCINYLDIAMINOPIMTRANS-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14267"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00821"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04475"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104301"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn03087"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01637_c0" sboTerm="SBO:0000176" id="R_rxn01637_c0" name="N2-Acetyl-L-ornithine:2-oxoglutarate aminotransferase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01637_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ACOTA"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACETYLORNTRANSAM-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.11"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00818"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00821"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02283"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95388"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01637"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn16823_c0" sboTerm="SBO:0000176" id="R_rxn16823_c0" name="thiazole tautomerase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn16823_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12609"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/5.3.99.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10810"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09977"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn16823"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_cpd01042_transport" sboTerm="SBO:0000176" id="R_cpd01042_transport" name="p-Cresol transport by diffusion" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction metaid="meta_R_rxn08642_c0" sboTerm="SBO:0000185" id="R_rxn08642_c0" name="Glycerol-3-phosphate:phosphate antiport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn08642_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLYC3Pt6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN-22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reactions/MNXR100321"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05301_c0" sboTerm="SBO:0000185" id="R_rxn05301_c0" name="L-Tyrosine:proton symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05301_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/TYRt2pp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN-77"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105003"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05669_c0" sboTerm="SBO:0000185" id="R_rxn05669_c0" name="L-Valine:proton symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05669_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/VALt2r"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105188"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05242_c0" sboTerm="SBO:0000185" id="R_rxn05242_c0" name="L-Valine:sodium symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05242_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/VALt4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN-126A"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105189"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction id="R_rxn05171_c0" name="nitrate-transporting ATPase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction metaid="meta_R_rxn00979_c0" sboTerm="SBO:0000176" id="R_rxn00979_c0" name="glycolaldehyde:NAD+ oxidoreductase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn00979_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GCALDD"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYCOLALD-DEHYDROG-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.21"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01333"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100060"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00979"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15505"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_cpd23538_trans" sboTerm="SBO:0000185" id="R_cpd23538_trans" name="(S)-2,3-dihydroxypropane-1-sulfonate:sodium symport" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction metaid="meta_R_rxn22083_c0" sboTerm="SBO:0000176" id="R_rxn22083_c0" name="(S)-sulfopropanediol 2-dehydrogenase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn22083_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META: RXN-11728"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR117124"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn22083"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn22084_c0" sboTerm="SBO:0000176" id="R_rxn22084_c0" name="(R)-sulfopropanediol 2-dehydrogenase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn22084_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META: RXN-11729"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn22084"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn16387_c0" sboTerm="SBO:0000176" id="R_rxn16387_c0" name="(R)-2,3-dihydroxypropane-1-sulfonate:NAD+ 3-oxidoreductase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn16387_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11727"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.308"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09545"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn16337"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn04934_c0" sboTerm="SBO:0000176" id="R_rxn04934_c0" name="(2R)-3-sulfolactate:NAD+ oxidoreductase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn04934_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/SLDx"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.1.1.272-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:R230-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.272"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07136"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn04934"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn07450_c0" sboTerm="SBO:0000176" id="R_rxn07450_c0" name="L-cysteate bisulfite-lyase (deaminating)" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn07450_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:4.4.1.25-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.4.1.25"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07634"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07450"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction id="R_rxn10480_c0" name="CO transporter via diffusion" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction id="R_rxn09799_c0" name="Transport of (R)-2-oxoisovalerate, mitochondrial" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction metaid="meta_R_rxn47974_c0" id="R_rxn47974_c0" name="3-Mercaptopyruvate:sulfide sulfurtransferase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn47974_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MERCAPYSTRANS-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03105"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02229"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01900"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05708_c0" sboTerm="SBO:0000185" id="R_rxn05708_c0" name="Formamide transport via proton symport" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05708_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05708"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </reaction>
+      <reaction metaid="meta_R_rxn00510_c0" sboTerm="SBO:0000176" id="R_rxn00510_c0" name="N6-(L-1,3-Dicarboxypropyl)-L-lysine:NAD+ oxidoreductase (L-lysine-forming)" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn00510_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/SACCD2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.5.1.7-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.1.7"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00715"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR188816"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00510"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14625"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01906_c0" sboTerm="SBO:0000176" id="R_rxn01906_c0" name="3-sulfino-L-alanine:2-oxoglutarate aminotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01906_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.6.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02619"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01906_c0"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10500"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_aminopent_redox" sboTerm="SBO:0000176" id="R_aminopent_redox" name="5-aminopentanal:NAD+ 1-oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_aminopent_redox">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.19"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R12215"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/aminopent_redox"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15505"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01141_c0" sboTerm="SBO:0000176" id="R_rxn01141_c0" name="N,N-Dimethylglycine:oxygen oxidoreductase (demethylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01141_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.5.3.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01564"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01141_c0"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04960"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01366_c0" sboTerm="SBO:0000176" id="R_rxn01366_c0" name="Uridine:phosphate alpha-D-ribosyltransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01366_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01876"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01366_c0"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04960"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01392_c0" sboTerm="SBO:0000176" id="R_rxn01392_c0" name="Xylitol:NADP+ 4-oxidoreductase (L-xylulose-forming) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01392_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01904"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01392_c0"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10520"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01548_c0" sboTerm="SBO:0000176" id="R_rxn01548_c0" name="guanosine:phosphate alpha-D-ribosyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01548_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.4.2.15"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02147"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01548_c0"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04960"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01630_c0" sboTerm="SBO:0000176" id="R_rxn01630_c0" name="5-Aminopentanamide amidohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01630_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.30"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02273"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01630_c0"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08175"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn02229_c0" sboTerm="SBO:0000176" id="R_rxn02229_c0" name="3-Mercaptopyruvate:cyanide sulfurtransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn02229_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03105"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02229_c0"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01900"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn02877_c0" sboTerm="SBO:0000176" id="R_rxn02877_c0" name="cis-1,2-dihydronaphthalene-1,2-diol:NAD+ 1,2-oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn02877_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.29"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04115"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02877_c0"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07990"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn04600_c0" sboTerm="SBO:0000176" id="R_rxn04600_c0" name="(2E)-3-(cis-5,6-dihydroxycyclohexa-1,3-dien-1-yl)prop-2-enoate:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn04600_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.87"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R06785"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn04600_c0"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07990"/>
+        </fbc:geneProductAssociation>
       </reaction>
     </listOfReactions>
     <fbc:listOfObjectives fbc:activeObjective="obj">
@@ -74102,6 +76536,12 @@
         </annotation>
       </fbc:geneProduct>
       <fbc:geneProduct fbc:id="G_MASE_RS04050" fbc:name="G_MASE_RS04050" fbc:label="G_MASE_RS04050"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS12865" fbc:name="G_MASE_RS12865" fbc:label="G_MASE_RS12865"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS06865" fbc:name="G_MASE_RS06865" fbc:label="G_MASE_RS06865"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS01900" fbc:name="G_MASE_RS01900" fbc:label="G_MASE_RS01900"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS04960" fbc:name="G_MASE_RS04960" fbc:label="G_MASE_RS04960"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS10520" fbc:name="G_MASE_RS10520" fbc:label="G_MASE_RS10520"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS08175" fbc:name="G_MASE_RS08175" fbc:label="G_MASE_RS08175"/>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>

--- a/model.xml
+++ b/model.xml
@@ -21611,6 +21611,624 @@
           </rdf:RDF>
         </annotation>
       </species>
+      <species metaid="meta_M_cpd14954_c0" sboTerm="SBO:0000247" id="M_cpd14954_c0" name="Protein N6-(lipoyl)lysine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C8H14NORS2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd14954_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C16237"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd14954"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd16584_c0" sboTerm="SBO:0000247" id="M_cpd16584_c0" name="Protein N6-(dihydrolipoyl)lysine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C8H16NORS2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd16584_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C16832"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd16584"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd15217_c0" sboTerm="SBO:0000247" id="M_cpd15217_c0" name="S-Aminomethyldihydrolipoamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C9H21N2OS2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd15217_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/alpam"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C9H20N2OS2/c10-7-14-6-5-8(13)3-1-2-4-9(11)12/h8,13H,1-7,10H2,(H2,11,12)"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/KALYVIJGKPJBQV-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01242"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15217"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd02522_c0" sboTerm="SBO:0000247" id="M_cpd02522_c0" name="2-Aminoadipate 6-semialdehyde [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H11NO3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd02522_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/L2aadp6sa"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd02522"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00418_c0" sboTerm="SBO:0000247" id="M_cpd00418_c0" name="NO [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="NO">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00418_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/no"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NITRIC-OXIDE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/NO/c1-2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/MWUXSHHQAYIFBG-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM228"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM162249"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00418"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00418_e0" sboTerm="SBO:0000247" id="M_cpd00418_e0" name="NO [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="NO">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00418_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/no"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NITRIC-OXIDE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/NO/c1-2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/MWUXSHHQAYIFBG-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00533"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM228"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM162249"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00418"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd24682_c0" sboTerm="SBO:0000247" id="M_cpd24682_c0" name="4Fe4S iron-sulfur cluster [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="S4Fe4">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd24682_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/4fe4s"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:4Fe-4S+2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/4Fe.4S/q;;2*+1;;;;"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/YEAYMLBNRJYVPB-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C22154"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM732007"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd24682"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd15380_c0" sboTerm="SBO:0000247" id="M_cpd15380_c0" name="5&apos;-deoxyribose [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H10O4">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd15380_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/5drib"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H13N5O3/c1-4-6(16)7(17)10(18-4)15-3-14-5-8(11)12-2-13-9(5)15/h2-4,6-7,10,16-17H,1H3,(H2,11,12,13)/t4-,6-,7-,10-/m1/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/XGYIMTFOTBMPFP-KQYNXXCUSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05198"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1103313"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15380"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd15380_e0" sboTerm="SBO:0000247" id="M_cpd15380_e0" name="5&apos;-deoxyribose [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H10O4">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd15380_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/5drib"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H13N5O3/c1-4-6(16)7(17)10(18-4)15-3-14-5-8(11)12-2-13-9(5)15/h2-4,6-7,10,16-17H,1H3,(H2,11,12,13)/t4-,6-,7-,10-/m1/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/XGYIMTFOTBMPFP-KQYNXXCUSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05198"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1103313"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15380"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd11912_c0" sboTerm="SBO:0000247" id="M_cpd11912_c0" name="tRNA-Glu [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C10H12N5O3R">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd11912_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/trnaglu"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLT-tRNAs"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90886"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11912"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd12227_c0" sboTerm="SBO:0000247" id="M_cpd12227_c0" name="L-Glutamyl-tRNA-Glu [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H34N6O19P2R2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd12227_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/glutrna"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02987"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM731031"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd12227"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd01042_e0" sboTerm="SBO:0000247" id="M_cpd01042_e0" name="p-Cresol [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C7H8O">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd01042_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/4crsol"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-108"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C7H8O/c1-6-2-4-7(8)5-3-6/h2-5,8H,1H3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/IWDCLRJOBJJRNH-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01468"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM828"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01042"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00080_e0" sboTerm="SBO:0000247" id="M_cpd00080_e0" name="Glycerol-3-phosphate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C3H7O6P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00080_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/glyc3p"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYCEROL-3P"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H9O6P/c4-1-3(5)2-9-10(6,7)8/h3-5H,1-2H2,(H2,6,7,8)/p-2/t3-/m1/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/AWUCVROLDVIAJX-GSVOUGTGSA-L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00093"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM66"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00080"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00069_e0" sboTerm="SBO:0000247" id="M_cpd00069_e0" name="L-Tyrosine [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C9H11NO3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00069_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/tyr__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TYR"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C9H11NO3/c10-8(9(12)13)5-6-1-3-7(11)4-2-6/h1-4,8,11H,5,10H2,(H,12,13)/t8-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/OUYCCCASQSFEME-QMMMGPOBSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00082"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM76"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00069"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00156_e0" sboTerm="SBO:0000247" id="M_cpd00156_e0" name="L-Valine [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H11NO2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00156_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/val__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:VAL"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C5H11NO2/c1-3(2)4(6)5(7)8/h3-4H,6H2,1-2H3,(H,7,8)/t4-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/KZSNJWFQEVHDMF-BYPYZUCNSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00183"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM199"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00156"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00209_e0" id="M_cpd00209_e0" name="Nitrate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="NO3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00209_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/aracyc/NITRATE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg/no3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/brachycyc/NITRATE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg/C00244"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metacyc/CPD-15028"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metacyc/NITRATE"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd23538_c0" sboTerm="SBO:0000247" id="M_cpd23538_c0" name="(S)-2,3-dihydroxypropane-1-sulfonate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C3H7O5S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd23538_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-12693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H8O5S/c4-1-3(5)2-9(6,7)8/h3-5H,1-2H2,(H,6,7,8)/p-1/t3-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/InChIKey=YPFUJZAAZJXMIP-VKHMYHEASA-M"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C22383"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM13761"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd23538"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd23538_e0" sboTerm="SBO:0000247" id="M_cpd23538_e0" name="(S)-2,3-dihydroxypropane-1-sulfonate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C3H7O5S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd23538_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-12693"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H8O5S/c4-1-3(5)2-9(6,7)8/h3-5H,1-2H2,(H,6,7,8)/p-1/t3-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/InChIKey=YPFUJZAAZJXMIP-VKHMYHEASA-M"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C22383"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM13761"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd23538"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd23539_c0" sboTerm="SBO:0000247" id="M_cpd23539_c0" name="2-oxo-3-hydroxy-propane-1-sulfonate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C3H5O5S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd23539_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-12694"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H6O5S/c4-1-3(5)2-9(6,7)8/h4H,1-2H2,(H,6,7,8)/p-1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/InChIKey=MZULZEBLIRPPES-UHFFFAOYSA-M"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM9878"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd23539"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd20923_c0" sboTerm="SBO:0000247" id="M_cpd20923_c0" name="(R)-2,3-dihydroxypropane-1-sulfonate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C3H7O5S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd20923_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-12692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H8O5S/c4-1-3(5)2-9(6,7)8/h3-5H,1-2H2,(H,6,7,8)/p-1/t3-/m1/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/InChIKey=YPFUJZAAZJXMIP-GSVOUGTGSA-M"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C19675"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3743"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd20923"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd08367_c0" sboTerm="SBO:0000247" id="M_cpd08367_c0" name="(2R)-3-Sulfolactate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C3H4O6S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd08367_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/sl__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-367"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H6O6S/c4-2(3(5)6)1-10(7,8)9/h2,4H,1H2,(H,5,6)(H,7,8,9)/p-2/t2-/m1/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/CQQGIWJSICOUON-UWTATZPHSA-L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11537"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/CQQGIWJSICOUON-UWTATZPHSA-L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd08367"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00204_e0" id="M_cpd00204_e0" name="CO [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="CHO">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00204_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/aracyc/CARBON-MONOXIDE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg/co"/>
+                  <rdf:li rdf:resource="https://identifiers.org/brachycyc/CARBON-MONOXIDE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg/C00237"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metacyc/CARBON-MONOXIDE"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00123_e0" id="M_cpd00123_e0" name="3-Methyl-2-oxobutanoate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C5H7O3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00123_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/aracyc/2-KETO-ISOVALERATE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg/3mob"/>
+                  <rdf:li rdf:resource="https://identifiers.org/brachycyc/2-KETO-ISOVALERATE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg/C00141"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metacyc/2-KETO-ISOVALERATE"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00378_e0" sboTerm="SBO:0000247" id="M_cpd00378_e0" name="Formamide [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="CH3NO">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00378_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/frmd"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:FORMAMIDE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/CH3NO/c2-1-3/h1H,(H2,2,3)"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/ZHNUHDYFZUAESO-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00488"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1231"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00378"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00351_c0" sboTerm="SBO:0000247" id="M_cpd00351_c0" name="Saccharopine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C11H19N2O6">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00351_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/saccrp__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SACCHAROPINE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C11H20N2O6/c12-7(10(16)17)3-1-2-6-13-8(11(18)19)4-5-9(14)15/h7-8,13H,1-6,12H2,(H,14,15)(H,16,17)(H,18,19)/p-1/t7-,8-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/ZDGJAHTZVHVLOT-YUMQZZPRSA-M"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00449"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM384"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00351"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00467_c0" sboTerm="SBO:0000247" id="M_cpd00467_c0" name="3-Sulfinoalanine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C3H6NO4S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00467_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00467"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd03284_c0" sboTerm="SBO:0000247" id="M_cpd03284_c0" name="3-Sulfinopyruvate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C3H2O5S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd03284_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03284"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd09206_c0" sboTerm="SBO:0000247" id="M_cpd09206_c0" name="5-Aminopentanal [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C5H12NO">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd09206_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd09206"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00183_c0" sboTerm="SBO:0000247" id="M_cpd00183_c0" name="Sarcosine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C3H7NO2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00183_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00183"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00756_c0" sboTerm="SBO:0000247" id="M_cpd00756_c0" name="Dimethylglycine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C4H9NO2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00756_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00756"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00475_c0" sboTerm="SBO:0000247" id="M_cpd00475_c0" name="Ribose 1-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C5H9O8P">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00475_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00475"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00261_c0" sboTerm="SBO:0000247" id="M_cpd00261_c0" name="L-Lyxulose [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H10O5">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00261_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/xylu__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:L-XYLULOSE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C5H10O5/c6-1-3(8)5(10)4(9)2-7/h3,5-8,10H,1-2H2/t3-,5+/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/ZAQJHHRNXZUBTE-WVZVXSGGSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00312"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1282"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00261"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00306_c0" sboTerm="SBO:0000247" id="M_cpd00306_c0" name="Xylitol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H12O5">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00306_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00306"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00729_c0" sboTerm="SBO:0000247" id="M_cpd00729_c0" name="5-Aminopentanamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C5H13N2O">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00729_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00729"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd01932_c0" sboTerm="SBO:0000247" id="M_cpd01932_c0" name="1,2-Naphthalenediol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C10H8O2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd01932_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01932"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd02646_c0" sboTerm="SBO:0000247" id="M_cpd02646_c0" name="cis-1,2-Dihydronaphthalene-1,2-diol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C10H10O2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd02646_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd02646"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd09253_c0" sboTerm="SBO:0000247" id="M_cpd09253_c0" name="cis-3-(3-Carboxyethenyl)-3,5-cyclohexadiene-1,2-diol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C9H9O4">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd09253_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd09253"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd09254_c0" sboTerm="SBO:0000247" id="M_cpd09254_c0" name="2,3-dihydroxicinnamic acid [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C9H7O4">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd09254_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd09254"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
     </listOfSpecies>
     <listOfParameters>
       <parameter sboTerm="SBO:0000626" id="cobra_default_lb" value="-1000" constant="true"/>
@@ -21732,8 +22350,8 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00213_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd14700_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
@@ -22149,8 +22767,8 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00213_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd03049_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
@@ -25184,6 +25802,7 @@
         <listOfReactants>
           <speciesReference species="M_cpd11464_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11492_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
@@ -25517,8 +26136,8 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00213_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd03189_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
@@ -25551,8 +26170,8 @@
         <listOfProducts>
           <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00018_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd15239_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:and>
@@ -27358,8 +27977,8 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd11469_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
@@ -28714,6 +29333,7 @@
         <listOfReactants>
           <speciesReference species="M_cpd00022_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11492_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
@@ -29300,8 +29920,8 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00449_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00481_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
@@ -29612,7 +30232,6 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00080_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd15268_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -29948,6 +30567,7 @@
         <listOfReactants>
           <speciesReference species="M_cpd11474_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11492_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
@@ -30128,7 +30748,6 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11476_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
@@ -30590,6 +31209,7 @@
         <listOfReactants>
           <speciesReference species="M_cpd11468_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11492_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
@@ -30927,7 +31547,7 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00078_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00449_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
@@ -31334,8 +31954,8 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00213_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd14698_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
@@ -33049,8 +33669,8 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd11475_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
@@ -33775,6 +34395,7 @@
         <listOfProducts>
           <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11485_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07915"/>
@@ -33868,9 +34489,9 @@
           <speciesReference species="M_cpd11493_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd00834_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd12370_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11605"/>
@@ -34812,7 +35433,7 @@
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00022_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00449_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13975"/>
@@ -34849,6 +35470,7 @@
         <listOfProducts>
           <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11489_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07915"/>
@@ -36739,8 +37361,8 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd11465_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
@@ -38249,6 +38871,7 @@
         <listOfProducts>
           <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11486_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07915"/>
@@ -39069,7 +39692,6 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00070_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11493_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -39288,6 +39910,7 @@
         <listOfReactants>
           <speciesReference species="M_cpd11492_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11494_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
@@ -39687,6 +40310,7 @@
         <listOfProducts>
           <speciesReference species="M_cpd00045_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11493_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03205"/>
@@ -39779,8 +40403,8 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00213_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd14702_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
@@ -41045,12 +41669,12 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00378_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
           <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00344_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00378_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:and>
@@ -41088,6 +41712,7 @@
         <listOfProducts>
           <speciesReference species="M_cpd02835_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11493_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12415"/>
@@ -41827,7 +42452,6 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11825_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd15328_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
@@ -43117,9 +43741,9 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd00080_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11825_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd11493_c0" stoichiometry="1" constant="true"/>
@@ -43194,6 +43818,7 @@
         <listOfProducts>
           <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11488_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07915"/>
@@ -43217,6 +43842,7 @@
         <listOfReactants>
           <speciesReference species="M_cpd11476_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11492_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
@@ -44111,8 +44737,8 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00449_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd01882_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
@@ -44258,6 +44884,7 @@
         <listOfProducts>
           <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11491_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07915"/>
@@ -46436,11 +47063,11 @@
         <listOfReactants>
           <speciesReference species="M_cpd00033_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd12005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11830_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd15217_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13790"/>
@@ -49170,9 +49797,9 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd00080_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd15294_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd11493_c0" stoichiometry="1" constant="true"/>
@@ -50426,12 +51053,12 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00087_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11830_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd15217_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00125_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd12225_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:and>
@@ -50932,8 +51559,8 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd11467_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
@@ -52094,12 +52721,12 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00449_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00213_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13970"/>
@@ -52277,9 +52904,9 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd00080_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd15239_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd11493_c0" stoichiometry="1" constant="true"/>
@@ -53078,6 +53705,7 @@
         <listOfReactants>
           <speciesReference species="M_cpd11466_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11492_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
@@ -53787,9 +54415,9 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd00080_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15277_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11476_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd11493_c0" stoichiometry="1" constant="true"/>
@@ -54391,8 +55019,8 @@
         <listOfProducts>
           <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00018_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd15294_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:and>
@@ -55402,7 +56030,6 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00037_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11484_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
@@ -57378,7 +58005,6 @@
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11475_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
@@ -57990,8 +58616,8 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00449_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00760_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
@@ -58724,6 +59350,7 @@
         <listOfReactants>
           <speciesReference species="M_cpd11470_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd11492_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
@@ -59426,12 +60053,12 @@
         </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11621_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd11621_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11620_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd11620_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12165"/>
@@ -59485,13 +60112,17 @@
         <listOfReactants>
           <speciesReference species="M_cpd08289_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd14545_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd28259_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00084_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11620_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00001_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd21479_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd28253_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00018_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00035_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11621_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00460"/>
@@ -59602,6 +60233,7 @@
         <listOfReactants>
           <speciesReference species="M_cpd11492_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd36635_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
@@ -60725,14 +61357,14 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02465_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
           <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd21488_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd02465_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06645"/>
@@ -61060,7 +61692,7 @@
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00764_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01046_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd02522_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06240"/>
@@ -62361,6 +62993,7 @@
         <listOfReactants>
           <speciesReference species="M_cpd11492_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd27180_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
           <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
@@ -63206,12 +63839,12 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00040_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
           <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd14545_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00040_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn08502_e0" sboTerm="SBO:0000176" id="R_rxn08502_e0" name="enterobactin Fe(III) binding (spontaneous) [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -63576,7 +64209,6 @@
           <speciesReference species="M_cpd11463_c0" stoichiometry="0.5441666" constant="true"/>
           <speciesReference species="M_cpd11462_c0" stoichiometry="0.1911666" constant="true"/>
           <speciesReference species="M_cpd00010_c0" stoichiometry="0.00160004066244054" constant="true"/>
-          <speciesReference species="M_cpd11493_c0" stoichiometry="0.00160004066244054" constant="true"/>
           <speciesReference species="M_cpd00003_c0" stoichiometry="0.00160004066244054" constant="true"/>
           <speciesReference species="M_cpd00006_c0" stoichiometry="0.00160004066244054" constant="true"/>
           <speciesReference species="M_cpd00205_c0" stoichiometry="0.00160004066244054" constant="true"/>
@@ -63604,24 +64236,15 @@
           <speciesReference species="M_cpd00118_c0" stoichiometry="0.00160004066244054" constant="true"/>
           <speciesReference species="M_cpd00056_c0" stoichiometry="0.00160004066244054" constant="true"/>
           <speciesReference species="M_cpd15560_c0" stoichiometry="0.00160004066244054" constant="true"/>
-          <speciesReference species="M_cpd15352_c0" stoichiometry="0.00160004066244054" constant="true"/>
-          <speciesReference species="M_cpd15500_c0" stoichiometry="0.00160004066244054" constant="true"/>
-          <speciesReference species="M_cpd00166_c0" stoichiometry="0.00160004066244054" constant="true"/>
-          <speciesReference species="M_cpd15793_c0" stoichiometry="0.0248034535317025" constant="true"/>
           <speciesReference species="M_cpd15540_c0" stoichiometry="0.0248034535317025" constant="true"/>
           <speciesReference species="M_cpd15533_c0" stoichiometry="0.0248034535317025" constant="true"/>
           <speciesReference species="M_cpd03736_c0" stoichiometry="0.032079293220334" constant="true"/>
           <speciesReference species="M_cpd02229_c0" stoichiometry="0.032079293220334" constant="true"/>
-          <speciesReference species="M_cpd15665_c0" stoichiometry="0.032079293220334" constant="true"/>
           <speciesReference species="M_cpd00002_c0" stoichiometry="40" constant="true"/>
           <speciesReference species="M_cpd00001_c0" stoichiometry="40" constant="true"/>
         </listOfReactants>
         <listOfProducts>
-          <speciesReference species="M_cpd12370_c0" stoichiometry="0.00160004066244054" constant="true"/>
           <speciesReference species="M_cpd00009_c0" stoichiometry="39.9983999593376" constant="true"/>
-          <speciesReference species="M_cpd01997_c0" stoichiometry="0.00160004066244054" constant="true"/>
-          <speciesReference species="M_cpd03422_c0" stoichiometry="0.00160004066244054" constant="true"/>
-          <speciesReference species="M_cpd15666_c0" stoichiometry="0.032079293220334" constant="true"/>
           <speciesReference species="M_cpd00008_c0" stoichiometry="40" constant="true"/>
           <speciesReference species="M_cpd00067_c0" stoichiometry="40" constant="true"/>
           <speciesReference species="M_cpd11416_c0" stoichiometry="1" constant="true"/>
@@ -64054,8 +64677,29 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00418_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00418_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_FeS_cluster_biosynth" sboTerm="SBO:0000176" id="R_FeS_cluster_biosynth" name="[4Fe4S] iron-sulfur cluster biosynthesis" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00084_c0" stoichiometry="4" constant="true"/>
+          <speciesReference species="M_cpd00982_c0" stoichiometry="3" constant="true"/>
+          <speciesReference species="M_cpd10515_c0" stoichiometry="4" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd24682_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00008_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00015_c0" stoichiometry="3" constant="true"/>
+          <speciesReference species="M_cpd00035_c0" stoichiometry="4" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="10" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12865"/>
         </fbc:geneProductAssociation>
@@ -64076,6 +64720,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03091_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd15380_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00128_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14795"/>
         </fbc:geneProductAssociation>
@@ -64093,6 +64745,12 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd15380_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd15380_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn06591_c0" sboTerm="SBO:0000176" id="R_rxn06591_c0" name="L-glutamate-semialdehyde: NADP+ oxidoreductase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64111,6 +64769,16 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd12227_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd11912_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd02345_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06865"/>
         </fbc:geneProductAssociation>
@@ -64133,8 +64801,25 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="3" constant="true"/>
+          <speciesReference species="M_cpd00791_c0" stoichiometry="2" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="6" constant="true"/>
+          <speciesReference species="M_cpd01476_c0" stoichiometry="2" constant="true"/>
+        </listOfProducts>
       </reaction>
-      <reaction metaid="meta_R_fe3_reduction" sboTerm="SBO:0000176" id="R_fe3_reduction" name="Reduction of Fe3+ by bacterioferritin-associated ferredoxin" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction metaid="meta_R_fe3_reduction" sboTerm="SBO:0000176" id="R_fe3_reduction" name="Reduction of Fe3+ by bacterioferritin-associated ferredoxin" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd10516_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd11620_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd10515_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd11621_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
       <reaction metaid="meta_R_rxn01213_c0" sboTerm="SBO:0000176" id="R_rxn01213_c0" name="Geranyl diphosphate synthase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -64158,6 +64843,15 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00113_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00202_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00283_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn03087_c0" sboTerm="SBO:0000176" id="R_rxn03087_c0" name="N-Succinyl-L-2,6-diaminoheptanedioate:2-oxoglutarate amino-transferase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64178,6 +64872,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd02724_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd02698_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn01637_c0" sboTerm="SBO:0000176" id="R_rxn01637_c0" name="N2-Acetyl-L-ornithine:2-oxoglutarate aminotransferase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64198,6 +64900,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00918_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00342_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn16823_c0" sboTerm="SBO:0000176" id="R_rxn16823_c0" name="thiazole tautomerase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64215,8 +64925,21 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd21479_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd21480_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
-      <reaction metaid="meta_R_cpd01042_transport" sboTerm="SBO:0000176" id="R_cpd01042_transport" name="p-Cresol transport by diffusion" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction metaid="meta_R_cpd01042_transport" sboTerm="SBO:0000176" id="R_cpd01042_transport" name="p-Cresol transport by diffusion" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd01042_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd01042_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
       <reaction metaid="meta_R_rxn08642_c0" sboTerm="SBO:0000185" id="R_rxn08642_c0" name="Glycerol-3-phosphate:phosphate antiport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -64231,6 +64954,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00080_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00009_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00080_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn05301_c0" sboTerm="SBO:0000185" id="R_rxn05301_c0" name="L-Tyrosine:proton symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64246,6 +64977,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00069_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00069_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn05669_c0" sboTerm="SBO:0000185" id="R_rxn05669_c0" name="L-Valine:proton symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64260,6 +64999,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00156_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00156_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn05242_c0" sboTerm="SBO:0000185" id="R_rxn05242_c0" name="L-Valine:sodium symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64275,8 +65022,28 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00156_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00156_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
-      <reaction id="R_rxn05171_c0" name="nitrate-transporting ATPase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction id="R_rxn05171_c0" name="nitrate-transporting ATPase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00209_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00008_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00209_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
       <reaction metaid="meta_R_rxn00979_c0" sboTerm="SBO:0000176" id="R_rxn00979_c0" name="glycolaldehyde:NAD+ oxidoreductase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -64294,11 +65061,28 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00229_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00139_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15505"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_cpd23538_trans" sboTerm="SBO:0000185" id="R_cpd23538_trans" name="(S)-2,3-dihydroxypropane-1-sulfonate:sodium symport" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction metaid="meta_R_cpd23538_trans" sboTerm="SBO:0000185" id="R_cpd23538_trans" name="(S)-2,3-dihydroxypropane-1-sulfonate:sodium symport" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd23538_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd23538_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
       <reaction metaid="meta_R_rxn22083_c0" sboTerm="SBO:0000176" id="R_rxn22083_c0" name="(S)-sulfopropanediol 2-dehydrogenase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -64313,6 +65097,15 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd23538_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd23539_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn22084_c0" sboTerm="SBO:0000176" id="R_rxn22084_c0" name="(R)-sulfopropanediol 2-dehydrogenase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64327,6 +65120,15 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd23539_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd20923_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn16387_c0" sboTerm="SBO:0000176" id="R_rxn16387_c0" name="(R)-2,3-dihydroxypropane-1-sulfonate:NAD+ 3-oxidoreductase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64343,6 +65145,16 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd20923_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd08367_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="3" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn04934_c0" sboTerm="SBO:0000176" id="R_rxn04934_c0" name="(2R)-3-sulfolactate:NAD+ oxidoreductase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64361,6 +65173,15 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd08367_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03285_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn07450_c0" sboTerm="SBO:0000176" id="R_rxn07450_c0" name="L-cysteate bisulfite-lyase (deaminating)" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64377,9 +65198,32 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00395_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00020_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00081_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
-      <reaction id="R_rxn10480_c0" name="CO transporter via diffusion" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub"/>
-      <reaction id="R_rxn09799_c0" name="Transport of (R)-2-oxoisovalerate, mitochondrial" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub"/>
+      <reaction id="R_rxn10480_c0" name="CO transporter via diffusion" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00204_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00204_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
+      <reaction id="R_rxn09799_c0" name="Transport of (R)-2-oxoisovalerate, mitochondrial" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00123_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00123_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
       <reaction metaid="meta_R_rxn47974_c0" id="R_rxn47974_c0" name="3-Mercaptopyruvate:sulfide sulfurtransferase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -64395,6 +65239,16 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00706_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11421_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00020_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00239_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11420_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01900"/>
         </fbc:geneProductAssociation>
@@ -64411,6 +65265,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00378_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00378_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn00510_c0" sboTerm="SBO:0000176" id="R_rxn00510_c0" name="N6-(L-1,3-Dicarboxypropyl)-L-lysine:NAD+ oxidoreductase (L-lysine-forming)" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64429,6 +65291,17 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00039_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00351_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14625"/>
         </fbc:geneProductAssociation>
@@ -64447,6 +65320,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00467_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd03284_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10500"/>
         </fbc:geneProductAssociation>
@@ -64465,6 +65346,16 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd09206_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00339_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15505"/>
         </fbc:geneProductAssociation>
@@ -64484,6 +65375,16 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00756_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00183_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00025_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00055_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04960"/>
         </fbc:geneProductAssociation>
@@ -64503,6 +65404,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00249_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00475_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00092_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04960"/>
         </fbc:geneProductAssociation>
@@ -64521,6 +65430,15 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00306_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00261_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10520"/>
         </fbc:geneProductAssociation>
@@ -64540,6 +65458,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00207_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00475_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00311_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04960"/>
         </fbc:geneProductAssociation>
@@ -64558,6 +65484,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00729_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00339_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08175"/>
         </fbc:geneProductAssociation>
@@ -64576,6 +65510,14 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00081_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00706_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00020_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00268_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01900"/>
         </fbc:geneProductAssociation>
@@ -64594,6 +65536,15 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd02646_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd01932_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07990"/>
         </fbc:geneProductAssociation>
@@ -64612,6 +65563,15 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd09253_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd09254_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07990"/>
         </fbc:geneProductAssociation>

--- a/model.xml
+++ b/model.xml
@@ -23715,7 +23715,7 @@
             <rdf:Description rdf:about="#meta_R_rxn01199_c0">
               <bqbiol:is>
                 <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01199_c0"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01199"/>
                   <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/XYLK"/>
                   <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/XKS1"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01639"/>

--- a/model.xml
+++ b/model.xml
@@ -28379,6 +28379,7 @@
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03610"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02025"/>
             </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18985"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -36718,6 +36719,7 @@
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03610"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02025"/>
             </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18985"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -51497,7 +51499,10 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11390"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11390"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15505"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn09449_c0" sboTerm="SBO:0000176" id="R_rxn09449_c0" name="acyl-coenzyme A ligase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -56980,6 +56985,7 @@
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17755"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02440"/>
             </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15505"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>

--- a/model.xml
+++ b/model.xml
@@ -64607,6 +64607,9 @@
           <speciesReference species="M_cpd10515_c0" stoichiometry="2" constant="true"/>
           <speciesReference species="M_cpd11621_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05555"/>
+        </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01213_c0" sboTerm="SBO:0000176" id="R_rxn01213_c0" name="Geranyl diphosphate synthase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64640,6 +64643,9 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00283_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12360"/>
+        </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03087_c0" sboTerm="SBO:0000176" id="R_rxn03087_c0" name="N-Succinyl-L-2,6-diaminoheptanedioate:2-oxoglutarate amino-transferase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64668,6 +64674,9 @@
           <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd02698_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01650"/>
+        </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01637_c0" sboTerm="SBO:0000176" id="R_rxn01637_c0" name="N2-Acetyl-L-ornithine:2-oxoglutarate aminotransferase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -64696,6 +64705,9 @@
           <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00342_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01650"/>
+        </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn16823_c0" sboTerm="SBO:0000176" id="R_rxn16823_c0" name="thiazole tautomerase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -77290,6 +77302,7 @@
       <fbc:geneProduct fbc:id="G_MASE_RS04960" fbc:name="G_MASE_RS04960" fbc:label="G_MASE_RS04960"/>
       <fbc:geneProduct fbc:id="G_MASE_RS10520" fbc:name="G_MASE_RS10520" fbc:label="G_MASE_RS10520"/>
       <fbc:geneProduct fbc:id="G_MASE_RS08175" fbc:name="G_MASE_RS08175" fbc:label="G_MASE_RS08175"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS05555" fbc:name="G_MASE_RS05555" fbc:label="G_MASE_RS05555"/>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>


### PR DESCRIPTION
This pull request:

<details>
<summary>Adds these metabolites to the model</summary>

- NO [c0] & [e0] (`cpd00418_c0` and `cpd00418_e0`)
- 5'-deoxyribose [c0] & [e0] (`cpd15380_c0` and `cpd15380_e0`)
- (S)-2,3-dihydroxypropane-1-sulfonate [c0] & [e0] (`cpd23538_c0` and `cpd23538_e0`)
- CO [e0] (`cpd00204_e0`)
- Nitrate [e0] (`cpd00209_e0`)
- p-Cresol [e0] (`cpd01042_e0`)
- Glycerol-3-phosphate [e0] (`cpd00080_e0`)
- L-Tyrosine [e0] (`cpd00069_e0`)
- L-Valine [e0] (`cpd00156_e0`)
- 3-Methyl-2-oxobutanoate [e0] (`cpd00123_e0`)
- Formamide [e0] (`cpd00378_e0`)
- Protein N6-(lipoyl)lysine [c0] (`cpd14954_c0`)
- Protein N6-(dihydrolipoyl)lysine [c0] (`cpd16584_c0`)
- S-Aminomethyldihydrolipoamide [c0] (`cpd15217_c0`)
- 2-Aminoadipate 6-semialdehyde [c0] (`cpd02522_c0`)
- Saccharopine [c0] (`cpd00351_c0`)
- 4Fe4S iron-sulfur cluster [c0] (`cpd24682_c0`)
- tRNA-Glu [c0] (`cpd11912_c0`)
- L-Glutamyl-tRNA-Glu [c0] (`cpd12227_c0`)
- 2-oxo-3-hydroxy-propane-1-sulfonate [c0] (`cpd23539_c0`)
- (R)-2,3-dihydroxypropane-1-sulfonate [c0] (`cpd20923_c0`)
- (2R)-3-Sulfolactate [c0] (`cpd08367_c0`)
- 3-Sulfinoalanine [c0] (`cpd00467_c0`)
- 3-Sulfinopyruvate [c0] (`cpd03284_c0`)
- 5-Aminopentanal [c0] (`cpd09206_c0`)
- Sarcosine [c0] (`cpd00183_c0`)
- Dimethylglycine [c0] (`cpd00756_c0`)
- Ribose 1-phosphate [c0] (`cpd00475_c0`)
- L-Lyxulose [c0] (`cpd00261_c0`)
- Xylitol [c0] (`cpd00306_c0`)
- 5-Aminopentanamide [c0] (`cpd00729_c0`)
- 1,2-Naphthalenediol [c0] (`cpd01932_c0`)
- cis-1,2-Dihydronaphthalene-1,2-diol [c0] (`cpd02646_c0`)
- cis-3-(3-Carboxyethenyl)-3,5-cyclohexadiene-1,2-diol [c0] (`cpd09253_c0`)
- 2,3-dihydroxicinnamic acid [c0] (`cpd09254_c0`)

</details>

<details>
<summary>Adds these reactions to the model</summary>

reaction ID | equation | GPR
----|---|---
`rxn10480_c0` | CO [c0] <=> CO [e0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/200)
`rxn09008_c0` | NO [c0] <=> NO [e0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/issues/58)
`cpd01042_transport` | p-Cresol [c0] --> p-Cresol [e0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/144)
`cpd15380_transport` | 5'-deoxyribose [c0] <=> 5'-deoxyribose [e0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/issues/99)
`cpd23538_trans` | (S)-2,3-dihydroxypropane-1-sulfonate [e0] <=> (S)-2,3-dihydroxypropane-1-sulfonate [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/179)
`rxn09799_c0` | 3-Methyl-2-oxobutanoate [c0] <=> 3-Methyl-2-oxobutanoate [e0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/202)
`rxn05708_c0` | H+ [c0] + Formamide [c0] <=> H+ [e0] + Formamide [e0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/215)
`rxn05301_c0` | H+ [e0] + L-Tyrosine [e0] --> H+ [c0] + L-Tyrosine [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/171)
`rxn05669_c0` | H+ [e0] + L-Valine [e0] --> H+ [c0] + L-Valine [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/171)
`rxn05242_c0` | L-Valine [e0] + Na+ [e0] --> L-Valine [c0] + Na+ [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/171)
`rxn08642_c0` | Phosphate [c0] + Glycerol-3-phosphate [e0] --> Phosphate [e0] + Glycerol-3-phosphate [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/171)
`rxn05171_c0` | H2O [c0] + ATP [c0] + Nitrate [e0] --> ADP [c0] + Phosphate [c0] + H+ [c0] + Nitrate [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/174)
`rxn02304_c0` | 3.0 O2 [c0] + 2.0 ProtoporphyrinogenIX [c0] --> 6.0 H2O [c0] + 2.0 Protoporphyrin [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/135)
`rxn16823_c0` | 2-[(2R,5Z)-2-Carboxy-4-methylthiazol-5(2H)-ylidene]ethyl phosphate [c0] --> 2-(2-Carboxy-4-methylthiazol-5-yl)ethyl phosphate [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/144)
`rxn22083_c0` | NADP [c0] + (S)-2,3-dihydroxypropane-1-sulfonate [c0] <=> NADPH [c0] + H+ [c0] + 2-oxo-3-hydroxy-propane-1-sulfonate [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/179)
`rxn22084_c0` | NADH [c0] + H+ [c0] + 2-oxo-3-hydroxy-propane-1-sulfonate [c0] <=> NAD [c0] + (R)-2,3-dihydroxypropane-1-sulfonate [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/179)
`rxn16387_c0` | H2O [c0] + 2.0 NAD [c0] + (R)-2,3-dihydroxypropane-1-sulfonate [c0] <=> 2.0 NADH [c0] + 3.0 H+ [c0] + (2R)-3-Sulfolactate [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/179)
`rxn04934_c0` | NAD [c0] + (2R)-3-Sulfolactate [c0] <=> NADH [c0] + H+ [c0] + 3-Sulfopyruvate [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/179)
`rxn07450_c0` | H2O [c0] + L-Cysteate [c0] --> NH3 [c0] + Pyruvate [c0] + Sulfite [c0] | none; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/179)
`rxn03087_c0` | L-Glutamate [c0] + N-Succinyl-L-2-amino-6-oxopimelate [c0] <=> 2-Oxoglutarate [c0] + N-Succinyl-L-2,6-diaminopimelate [c0] | `MASE_RS01650` (see [here](https://www.genome.jp/entry/amac:MASE_01650))
`rxn01637_c0` | L-Glutamate [c0] + 2-Acetamido-5-oxopentanoate [c0] <=> 2-Oxoglutarate [c0] + N-acetylornithine [c0] | `MASE_RS01650` (see [here](https://github.com/C-CoMP-STC/GEM-mit1002/pull/143) and [here](https://www.genome.jp/entry/amac:MASE_01650))
`rxn01213_c0` | Isopentenyldiphosphate [c0] + DMAPP [c0] --> PPi [c0] + H+ [c0] + Geranyldiphosphate [c0] | `MASE_RS12360` (see [here](https://www.genome.jp/entry/amac:MASE_12380))
`fe3_reduction` | 2.0 fe3 [c0] + Reducedferredoxin [c0] --> 2.0 Fe2+ [c0] + Oxidizedferredoxin [c0] | `MASE_RS05555`
`rxn47974_c0` | Mercaptopyruvate [c0] + Reduced thioredoxin [c0] <=> Pyruvate [c0] + H+ [c0] + Bisulfide (HS-) [c0] + Oxidized thioredoxin [c0] | `MASE_RS01900`
`rxn02229_c0` | Sulfite [c0] + Mercaptopyruvate [c0] <=> Pyruvate [c0] + H2S2O3 [c0] | `MASE_RS01900`
`rxn01906_c0` | 2-Oxoglutarate [c0] + 3-Sulfinoalanine [c0] <=> L-Glutamate [c0] + 3-Sulfinopyruvate [c0] | `MASE_RS10500`
`rxn00510_c0` | NADH [c0] + 2-Oxoglutarate [c0] + L-Lysine [c0] + H+ [c0] <=> H2O [c0] + NAD [c0] + Saccharopine [c0] | `MASE_RS14625`
`rxn00979_c0` | H2O [c0] + NAD [c0] + Glycolaldehyde [c0] <=> NADH [c0] + 2.0 H+ [c0] + Glycolate [c0] | `MASE_RS15505`
`aminopent_redox` | H2O [c0] + NAD [c0] + 5-Aminopentanal [c0] <=> NADH [c0] + H+ [c0] + 5-Aminopentanoate [c0] | `MASE_RS15505`
`FeS_cluster_biosynth` | H2O [c0] + ATP [c0] + 4.0 L-Cysteine [c0] + 3.0 FADH2 [c0] + 4.0 Fe2+ [c0] --> ADP [c0] + Phosphate [c0] + 3.0 FAD [c0] + 4.0 L-Alanine [c0] + 10.0 H+ [c0] + 4Fe4S iron-sulfur cluster [c0] | `MASE_RS12865`
`rxn08013_c0` | H2O [c0] + 5'-Deoxyadenosine [c0] --> Adenine [c0] + 5'-deoxyribose [c0] | `MASE_RS14795`
`rxn06591_c0` | NADPH [c0] + H+ [c0] + L-Glutamyl-tRNA-Glu [c0] --> NADP [c0] + L-Glutamate1-semialdehyde [c0] + tRNA-Glu [c0] | `MASE_RS06865`
`rxn01141_c0` | H2O [c0] + O2 [c0] + Dimethylglycine [c0] --> H2O2 [c0] + Formaldehyde [c0] + Sarcosine [c0] | `MASE_RS04960`
`rxn01392_c0` | NADP [c0] + Xylitol [c0] <=> NADPH [c0] + H+ [c0] + L-Lyxulose [c0] | `MASE_RS10520`
`rxn01366_c0` | Phosphate [c0] + Uridine [c0] <=> Uracil [c0] + Ribose 1-phosphate [c0] | `MASE_RS04960`
`rxn01548_c0` | Guanine [c0] + Ribose 1-phosphate [c0] --> Phosphate [c0] + Guanosine [c0] | `MASE_RS04960`
`rxn01630_c0` | H2O [c0] + 5-Aminopentanamide [c0] --> NH3 [c0] + 5-Aminopentanoate [c0] | `MASE_RS08175`
`rxn02877_c0` | NAD [c0] + cis-1,2-Dihydronaphthalene-1,2-diol [c0] --> NADH [c0] + H+ [c0] + 1,2-Naphthalenediol [c0] | `MASE_RS07990`
`rxn04600_c0` | NAD [c0] + cis-3-(3-Carboxyethenyl)-3,5-cyclohexadiene-1,2-diol [c0] --> NADH [c0] + H+ [c0] + 2,3-dihydroxicinnamic acid [c0] | `MASE_RS07990`

</details>

<details>
<summary>Changes the E.C. numbers of these reactions</summary>

- `rxn05334_c0`: from ['2.3.1.85', '2.3.1.86', '4.2.1.59', '4.2.1.58', '4.2.1.61'] to 4.2.1.59
- `rxn05346_c0`: from ['2.3.1.179', '2.3.1.85', '2.3.1.86', '2.3.1.41', '2.3.1.180'] to ['2.3.1.41', '2.3.1.179']
- `rxn05350_c0`: from ['2.3.1.179', '2.3.1.85', '2.3.1.86', '2.3.1.41', '2.3.1.180'] to ['2.3.1.41', '2.3.1.179']
- `rxn05324_c0`: from ['1.3.1.9', '2.3.1.86'] to 1.3.1.9
- `rxn05329_c0`: from 4.2.1.58 to 4.2.1.59
- `rxn05335_c0`: from ['4.2.1.59', '2.3.1.85', '4.2.1.61', '2.3.1.86'] to 4.2.1.59
- `rxn05348_c0`: from ['2.3.1.179', '2.3.1.85', '2.3.1.86', '2.3.1.41', '2.3.1.180'] to ['2.3.1.41', '2.3.1.179']
- `rxn05327_c0`: from ['1.3.1.9', '2.3.1.86'] to 1.3.1.9
- `rxn05336_c0`: from ['1.1.1.100', '2.3.1.85', '2.3.1.86'] to 1.1.1.100
- `rxn05340_c0`: from ['1.1.1.100', '2.3.1.85', '2.3.1.86'] to 1.1.1.100
- `rxn05322_c0`: from ['1.3.1.9', '2.3.1.86'] to 1.3.1.9
- `rxn05338_c0`: from ['1.1.1.100', '2.3.1.85', '2.3.1.86'] to 1.1.1.100
- `rxn05337_c0`: from ['1.1.1.100', '2.3.1.85', '2.3.1.86'] to 1.1.1.100
- `rxn05465_c0`: from ['2.3.1.39', '2.3.1.85', '2.3.1.86'] to 2.3.1.39
- `rxn05347_c0`: from ['2.3.1.179', '2.3.1.85', '2.3.1.86', '2.3.1.41', '2.3.1.180'] to ['2.3.1.41', '2.3.1.179']
- `rxn05325_c0`: from ['1.3.1.9', '2.3.1.86'] to 1.3.1.9
- `rxn05330_c0`: from ['4.2.1.59', '4.2.1.58', '2.3.1.85', '2.3.1.86'] to 4.2.1.59
- `rxn05339_c0`: from ['1.1.1.100', '2.3.1.85', '2.3.1.86'] to 1.1.1.100
- `rxn05460_c0`: from 2.3.1.0 to ['2.3.1.41', '2.3.1.179']
- `rxn05349_c0`: from ['2.3.1.179', '2.3.1.85', '2.3.1.86', '2.3.1.38', '2.3.1.180'] to 2.3.1.38
- `rxn05462_c0`: from 4.2.1.0 to 4.2.1.59
- `rxn05331_c0`: from ['2.3.1.85', '2.3.1.86', '4.2.1.60', '4.2.1.59', '4.2.1.58', '4.2.1.61'] to 4.2.1.59
- `rxn05341_c0`: from ['1.1.1.100', '2.3.1.85', '2.3.1.86'] to 1.1.1.100
- `rxn05328_c0`: from ['1.3.1.9', '2.3.1.86'] to 1.3.1.9
- `rxn05332_c0`: from ['2.3.1.85', '4.2.1.61', '2.3.1.86'] to 4.2.1.59
- `rxn05344_c0`: from ['2.3.1.179', '2.3.1.85', '2.3.1.86', '2.3.1.41', '2.3.1.180'] to ['2.3.1.41', '2.3.1.179']
- `rxn05326_c0`: from ['1.3.1.9', '2.3.1.86'] to 1.3.1.9
- `rxn05333_c0`: from ['2.3.1.85', '2.3.1.86', '4.2.1.60', '4.2.1.58', '4.2.1.61'] to 4.2.1.59
- `rxn05343_c0`: from ['2.3.1.179', '2.3.1.85', '2.3.1.86', '2.3.1.41', '2.3.1.180'] to ['2.3.1.41', '2.3.1.179']
- `thiazol_synth`: from 2.8.1.10 to ['2.8.1.7', '2.7.7.73', '2.8.1.10']

</details>

- Removes these metabolites from the biomass reaction:
  - ACP [c0] (`cpd11493_c0`)
  - apo-ACP [c0] (`cpd12370_c0`)
  - 2-Demethylmenaquinone 8 [c0] (`cpd15352_c0`)
  - Menaquinone 8 [c0] (`cpd15500_c0`)
  - Calomide [c0] (`cpd00166_c0`)
  - Cobinamide [c0] (`cpd03422_c0`)
  - Dimethylbenzimidazole [c0] (`cpd01997_c0`)
  - Stearoylcardiolipin (B. subtilis) [c0] (`cpd15793_c0`)
  - Peptidoglycan polymer (n subunits) [c0] (`cpd15665_c0`)
  - Peptidoglycan polymer (n-1 subunits) [c0] (`cpd15666_c0`)
- Replaces Allysine [c0] (`cpd01046_c0`) with 2-Aminoadipate 6-semialdehyde [c0] (`cpd02522_c0`) in `rxn40439_c0`
- Replaces Palmitoyl-ACP [c0] (`cpd15277_c0`) with Hexadecanoyl-ACP [c0] (`cpd11476_c0`) in `rxn08549_c0`
- Replaces Dihydrolipoamide [c0] (`cpd00449_c0`) with Protein N6-(dihydrolipoyl)lysine [c0] (`cpd16584_c0`) in `rxn01241_c0`, `rxn01871_c0`, `rxn01872_c0`, `rxn01925_c0`, `rxn06335_c0`, `rxn06586_c0`
- Replaces Lipoamide [c0] (`cpd00213_c0`) with Protein N6-(lipoyl)lysine [c0] (`cpd14954_c0`) in `rxn01241_c0`, `rxn02342_c0`, `rxn02376_c0`, `rxn07431_c0`, `rxn07433_c0`, `rxn07435_c0`
- Replaces Lipoylprotein [c0] (`cpd12005_c0`) with Protein N6-(lipoyl)lysine [c0] (`cpd14954_c0`) in `rxn09499_c0`
- Replaces Dihydrolipolprotein [c0] (`cpd12225_c0`) with Protein N6-(dihydrolipoyl)lysine [c0] (`cpd16584_c0`) in `rxn09498_c0`
- Replaces S-Aminomethyldihydrolipoylprotein [c0] (`cpd11830_c0`) with S-Aminomethyldihydrolipoamide [c0] (`cpd15217_c0`) in `rxn09498_c0` and `rxn09499_c0`
- Removes these metabolites from the model:
  - Lipoamide [c0] (`cpd00213_c0`)
  - Dihydrolipoamide [c0] (`cpd00449_c0`)
  - Arabinan [c0] (`cpd12115_c0`)
  - L-Arabinose [c0] (`cpd00224_c0`)
  - Lipoylprotein [c0] (`cpd12005_c0`)
  - S-Aminomethyldihydrolipoylprotein [c0] (`cpd11830_c0`)
  - Dihydrolipolprotein [c0] (`cpd12225_c0`)
  - Palmitoyl-ACP [c0] (`cpd15277_c0`)
  - Thiocarboxyadenylated-ThiS-Proteins [c0] (`cpd28259_c0`)
  - Allysine [c0] (`cpd01046_c0`)
  - Stearoylcardiolipin (B. subtilis) [c0] (`cpd15793_c0`)
  - Dimethylbenzimidazole [c0] (`cpd01997_c0`)
- Adds H+ [c0] (`cpd00067_c0`) to `rxn05343_c0`, `rxn05344_c0`, `rxn05345_c0`, `rxn05346_c0`, `rxn05347_c0`, `rxn05348_c0`, `rxn05460_c0`, `rxn08766_c0`, `rxn21860_c0`, and `rxn47768_c0` with a coefficient of -1
- Adds H+ [c0] (`cpd00067_c0`) to `rxn05336_c0`, `rxn05337_c0`, `rxn05339_c0`, `rxn05340_c0`, `rxn05342_c0`, `rxn06023_c0`, and `rxn06723_c0` with a coefficient of 1
- Changes the coefficient of H+ [c0] (`cpd00067_c0`) from 2 to 1 in `rxn06022_c0`, `rxn08015_c0`, and `rxn08017_c0`
- Changes the coefficient of H+ [c0] (`cpd00067_c0`) from -2 to -1 in `rxn05322_c0`, `rxn05323_c0`, `rxn05324_c0`, `rxn05327_c0`, `rxn08548_c0`, `rxn08549_c0`, `rxn08550_c0`, and `rxn08552_c0`
- Removes H+ (`cpd00067_c0`) from `rxn05333_c0`, `rxn05458_c0`, `rxn05465_c0`, `rxn06729_c0`, `rxn08089_c0`, and `rxn08551_c0`
- Changes the coefficient of Reducedferredoxin (`cpd11620_c0`) from 2 to 1 and the coefficient of Oxidizedferredoxin (`cpd11621_c0`) from -2 to -1 in `rxn05937_c0` 
- Changes ID of `rxn06377_c0` to `rxn09499_c0`
- Changes ID of `rxn06600_c0` to `rxn09498_c0`
- Changes ID of `rxn14159_c0` to `rxn05937_c0`
- Changes ID of `rxn27289_c0` to `thiazol_synth`
- Edits [thiazol_synth](https://github.com/C-CoMP-STC/GEM-mit1002/pull/144) to be: Iminoglycine + 1-deoxy-D-xylulose5-phosphate + L-Cysteine + ATP + Reducedferredoxin => 2-[(2R,5Z)-2-Carboxy-4-methylthiazol-5(2H)-ylidene]ethyl phosphate + L-Alanine + AMP + PPi + 2 H2O + Oxidizedferredoxin
- Makes `rxn00469_c0` irreversible
- Makes `rxn00872_c0`, `rxn01199_c0`, `rxn01924_c0`, `rxn02167_c0`, `rxn02270_c0`, `rxn02866_c0`, and `rxn05289_c0` reversible
- Swaps the products and reactants of these reactions:
  - `rxn01639_c0`
  - `rxn23589_c0`
  - `rxn39452_c0`
- Adds `MASE_RS18985` to the GPRs of `rxn00831_c0` and `rxn00913_c0`
- Adds `MASE_RS15505` to the GPRs of `rxn00183_c0` and `rxn00507_c0`
- Adds KEGG orthology IDs to the annotations of 705 reactions

This pull request copies all reactions in [the MIT1002 model](https://github.com/C-CoMP-STC/GEM-mit1002) that weren't already in this model and were associated with at least one gene that was present in both strains. It also edits all reactions that were already in this model but defined differently (e.g. had different metabolites and/or stoichiometric coefficients, went in different directions, etc.) to match their counterparts in the MIT1002 model, so that all of the problems that were identified and fixed in the MIT1002 model get propagated to this one.