### PR TITLE
Fix: Remove MASE_RS04055

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -72093,7 +72093,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04055" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04055" fbc:name="MASE_RS04055" fbc:label="G_MASE_RS04055"/>
       <fbc:geneProduct metaid="meta_G_MASE_RS04060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04060" fbc:name="MASE_RS04060" fbc:label="G_MASE_RS04060">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">


### PR DESCRIPTION
I intended to remove `MASE_RS04055` from the model in #1 (it's a pseudogene), but later realized that I somehow managed to forget, so I'm taking care of that now.