### PR TITLE
Feat: improve GPRs of FeS_cluster_biosynth and thiazol_synth reactions

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -59927,7 +59927,10 @@
           <speciesReference species="M_cpd11621_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00460"/>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00460"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00470"/>
+          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn42230_c0" sboTerm="SBO:0000176" id="R_rxn42230_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -64503,7 +64506,15 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="10" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12865"/>
+          <fbc:and>
+            <fbc:or>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12850"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12870"/>
+            </fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12865"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12860"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12855"/>
+          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08013_c0" sboTerm="SBO:0000176" id="R_rxn08013_c0" name="5&apos;-deoxyadenosine ribohydrolase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -77415,6 +77426,32 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949345.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12860" fbc:id="G_MASE_RS12860" fbc:name="sufC" fbc:label="G_MASE_RS12860">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12860">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950175.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12855" fbc:id="G_MASE_RS12855" fbc:name="sufD" fbc:label="G_MASE_RS12855">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12855">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950174.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>


### PR DESCRIPTION
This pull request:

- Adds `MASE_RS12855` (sufD) to the model
- Adds `MASE_RS12860` (sufC) to the model
- Changes the GPR of `FeS_cluster_biosynth` from `MASE_RS12865` to `(MASE_RS12850 or MASE_RS12870) and MASE_RS12865 and MASE_RS12860 and MASE_RS12855`
- Changes the GPR of `thiazol_synth` from `MASE_RS00460` to `MASE_RS00460 and MASE_RS00470`

While working on a new PR that removes all of the reactions, metabolites, and genes that were removed from the MIT1002 model, I came across a few genes that could be added to the GPRs of `FeS_cluster_biosynth` and `thiazol_biosynth` that I didn’t notice when working on #3.

`MASE_RS12865` was annotated as sufB, and `MASE_RS12850` and `MASE_RS12870` were both annotated as iscS; see [here](https://github.com/C-CoMP-STC/GEM-mit1002/issues/104) for information about those genes. See KEGG for more information about [MASE_RS00470](https://www.genome.jp/entry/AMAC+MASE_00460) and [MASE_RS00460](https://www.genome.jp/entry/AMAC+MASE_00450), as well as and the [MIT1002 model's PR #144](https://github.com/C-CoMP-STC/GEM-mit1002/pull/144)