### PR TITLE
Feat: add sufE gene to the model

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -63055,6 +63055,7 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12865"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12860"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12855"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12835"/>
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
@@ -75941,6 +75942,19 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950174.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </fbc:geneProduct>
+      <fbc:geneProduct metaid="meta_G_MASE_RS12835" fbc:id="G_MASE_RS12835" fbc:name="sufE" fbc:label="G_MASE_RS12835">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_G_MASE_RS12835">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950170.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>


### PR DESCRIPTION
This pull request:

- Changes the GPR of `FeS_cluster_biosynth` from `(MASE_RS12850 or MASE_RS12870) and MASE_RS12865 and MASE_RS12860 and MASE_RS12855` to `(MASE_RS12850 or MASE_RS12870) and MASE_RS12865 and MASE_RS12860 and MASE_RS12855 and MASE_RS12835` (adds `MASE_RS12835` to the end)

While [working on the HOT1A3 model](https://github.com/segrelab/GEM-hot1a3/pull/4), I noticed that [the sufE gene associated with the iron-sulfur cluster biosynthesis reaction in the MIT1002 model](https://github.com/C-CoMP-STC/GEM-mit1002/pull/128) has a reciprocal best blast hit in the ATCC27126 genome: `MASE_RS12835`, so I've added that to the GPR of `FeS_cluster_biosynth`.