### PR TITLE
Feat: copy metabolite name changes from MIT1002 model

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -15,7 +15,7 @@
       <compartment id="e0" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species metaid="meta_M_cpd00443_c0" sboTerm="SBO:0000247" id="M_cpd00443_c0" name="ABEE [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C7H6NO2">
+      <species metaid="meta_M_cpd00443_c0" sboTerm="SBO:0000247" id="M_cpd00443_c0" name="4-aminobenzoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C7H6NO2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00443_c0">
@@ -709,7 +709,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11441_c0" sboTerm="SBO:0000247" id="M_cpd11441_c0" name="fa6coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C37H63N7O17P3S">
+      <species metaid="meta_M_cpd11441_c0" sboTerm="SBO:0000247" id="M_cpd11441_c0" name="14-Methylpentadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C37H63N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11441_c0">
@@ -894,7 +894,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03049_c0" sboTerm="SBO:0000247" id="M_cpd03049_c0" name="2-Hydroxyethyl-ThPP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H21N4O8P2S">
+      <species metaid="meta_M_cpd03049_c0" sboTerm="SBO:0000247" id="M_cpd03049_c0" name="2-Hydroxyethyl-TPP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H21N4O8P2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03049_c0">
@@ -1034,7 +1034,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15736_c0" sboTerm="SBO:0000247" id="M_cpd15736_c0" name="Diglucosyl-1,2 diisohexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C47H88O15">
+      <species metaid="meta_M_cpd15736_c0" sboTerm="SBO:0000247" id="M_cpd15736_c0" name="1,2-di-14-methylpentadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C47H88O15">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15736_c0">
@@ -1158,7 +1158,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03114_c0" sboTerm="SBO:0000247" id="M_cpd03114_c0" name="3-Oxopalmitoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C37H60N7O18P3S">
+      <species metaid="meta_M_cpd03114_c0" sboTerm="SBO:0000247" id="M_cpd03114_c0" name="3-Oxohexadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C37H60N7O18P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03114_c0">
@@ -1177,7 +1177,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11466_c0" sboTerm="SBO:0000247" id="M_cpd11466_c0" name="Myristoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H48N2O8PRS">
+      <species metaid="meta_M_cpd11466_c0" sboTerm="SBO:0000247" id="M_cpd11466_c0" name="Tetradecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H48N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11466_c0">
@@ -1193,7 +1193,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd01695_c0" sboTerm="SBO:0000247" id="M_cpd01695_c0" name="Myristoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C35H58N7O17P3S">
+      <species metaid="meta_M_cpd01695_c0" sboTerm="SBO:0000247" id="M_cpd01695_c0" name="Tetradecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C35H58N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd01695_c0">
@@ -1550,7 +1550,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15688_c0" sboTerm="SBO:0000247" id="M_cpd15688_c0" name="CDP-1,2-diisohexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C44H79N3O15P2">
+      <species metaid="meta_M_cpd15688_c0" sboTerm="SBO:0000247" id="M_cpd15688_c0" name="CDP-1,2-di-14-methylpentadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C44H79N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15688_c0">
@@ -1668,7 +1668,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15727_c0" sboTerm="SBO:0000247" id="M_cpd15727_c0" name="Diisohexadecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H74O10P">
+      <species metaid="meta_M_cpd15727_c0" sboTerm="SBO:0000247" id="M_cpd15727_c0" name="1,2-di-14-methylpentadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H74O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15727_c0">
@@ -1778,7 +1778,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00193_c0" sboTerm="SBO:0000247" id="M_cpd00193_c0" name="APS [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C10H12N5O10PS">
+      <species metaid="meta_M_cpd00193_c0" sboTerm="SBO:0000247" id="M_cpd00193_c0" name="5&apos;-Adenylyl sulfate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C10H12N5O10PS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00193_c0">
@@ -2199,7 +2199,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15237_c0" sboTerm="SBO:0000247" id="M_cpd15237_c0" name="hexadecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H29O2">
+      <species metaid="meta_M_cpd15237_c0" sboTerm="SBO:0000247" id="M_cpd15237_c0" name="(9Z)-Hexadecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H29O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15237_c0">
@@ -2654,7 +2654,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15686_c0" sboTerm="SBO:0000247" id="M_cpd15686_c0" name="CDP-1,2-diisopentadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C42H75N3O15P2">
+      <species metaid="meta_M_cpd15686_c0" sboTerm="SBO:0000247" id="M_cpd15686_c0" name="CDP-1,2-di-13-methyltetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C42H75N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15686_c0">
@@ -2759,7 +2759,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11439_c0" sboTerm="SBO:0000247" id="M_cpd11439_c0" name="fa4coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C36H61N7O17P3S">
+      <species metaid="meta_M_cpd11439_c0" sboTerm="SBO:0000247" id="M_cpd11439_c0" name="12-Methyltetradecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C36H61N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11439_c0">
@@ -2773,7 +2773,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15675_c0" sboTerm="SBO:0000247" id="M_cpd15675_c0" name="1-anteisopentadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O7P">
+      <species metaid="meta_M_cpd15675_c0" sboTerm="SBO:0000247" id="M_cpd15675_c0" name="1-12-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15675_c0">
@@ -2821,7 +2821,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15682_c0" sboTerm="SBO:0000247" id="M_cpd15682_c0" name="1,2-diisohexadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C35H68O8P">
+      <species metaid="meta_M_cpd15682_c0" sboTerm="SBO:0000247" id="M_cpd15682_c0" name="1,2-di-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C35H68O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15682_c0">
@@ -2872,7 +2872,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11483_c0" sboTerm="SBO:0000247" id="M_cpd11483_c0" name="(R)-3-Hydroxyoctanoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H36N2O9PRS">
+      <species metaid="meta_M_cpd11483_c0" sboTerm="SBO:0000247" id="M_cpd11483_c0" name="(3R)-3-Hydroxyoctanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H36N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11483_c0">
@@ -2888,7 +2888,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11471_c0" sboTerm="SBO:0000247" id="M_cpd11471_c0" name="(2E)-Octenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H34N2O8PRS">
+      <species metaid="meta_M_cpd11471_c0" sboTerm="SBO:0000247" id="M_cpd11471_c0" name="(2E)-Octenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H34N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11471_c0">
@@ -2905,7 +2905,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11432_c0" sboTerm="SBO:0000247" id="M_cpd11432_c0" name="fa11coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C38H65N7O17P3S">
+      <species metaid="meta_M_cpd11432_c0" sboTerm="SBO:0000247" id="M_cpd11432_c0" name="15-Methylhexadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C38H65N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11432_c0">
@@ -2919,7 +2919,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15671_c0" sboTerm="SBO:0000247" id="M_cpd15671_c0" name="1-isoheptadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O7P">
+      <species metaid="meta_M_cpd15671_c0" sboTerm="SBO:0000247" id="M_cpd15671_c0" name="1-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15671_c0">
@@ -3050,7 +3050,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11513_c0" sboTerm="SBO:0000247" id="M_cpd11513_c0" name="12-methyl-3-hydroxy-tetra-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H49N2O9PRS">
+      <species metaid="meta_M_cpd11513_c0" sboTerm="SBO:0000247" id="M_cpd11513_c0" name="(3R)-3-hydroxy-12-methyltetradecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H49N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11513_c0">
@@ -3064,7 +3064,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11514_c0" sboTerm="SBO:0000247" id="M_cpd11514_c0" name="12-methyl-trans-tetra-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H47N2O8PRS">
+      <species metaid="meta_M_cpd11514_c0" sboTerm="SBO:0000247" id="M_cpd11514_c0" name="(2E)-12-methyltetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H47N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11514_c0">
@@ -3294,7 +3294,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15685_c0" sboTerm="SBO:0000247" id="M_cpd15685_c0" name="CDP-1,2-diisotetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C40H71N3O15P2">
+      <species metaid="meta_M_cpd15685_c0" sboTerm="SBO:0000247" id="M_cpd15685_c0" name="CDP-1,2-di-12-methyltridecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C40H71N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15685_c0">
@@ -3360,7 +3360,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11505_c0" sboTerm="SBO:0000247" id="M_cpd11505_c0" name="8-methyl-3-hydroxy-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H41N2O9PRS">
+      <species metaid="meta_M_cpd11505_c0" sboTerm="SBO:0000247" id="M_cpd11505_c0" name="(3R)-3-hydroxy-8-methyldecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H41N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11505_c0">
@@ -3374,7 +3374,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11506_c0" sboTerm="SBO:0000247" id="M_cpd11506_c0" name="8-methyl-trans-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H39N2O8PRS">
+      <species metaid="meta_M_cpd11506_c0" sboTerm="SBO:0000247" id="M_cpd11506_c0" name="(2E)-8-methyldecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H39N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11506_c0">
@@ -3606,7 +3606,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd01741_c0" sboTerm="SBO:0000247" id="M_cpd01741_c0" name="ddca [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C12H23O2">
+      <species metaid="meta_M_cpd01741_c0" sboTerm="SBO:0000247" id="M_cpd01741_c0" name="Dodecanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C12H23O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd01741_c0">
@@ -3801,7 +3801,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15308_c0" sboTerm="SBO:0000247" id="M_cpd15308_c0" name="1,2-Diacyl-sn-glycerol ditetradec-7-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H56O5">
+      <species metaid="meta_M_cpd15308_c0" sboTerm="SBO:0000247" id="M_cpd15308_c0" name="1,2-di-(7Z)-tetradecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H56O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15308_c0">
@@ -3816,7 +3816,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15523_c0" sboTerm="SBO:0000247" id="M_cpd15523_c0" name="1,2-ditetradec-7-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C31H56O8P">
+      <species metaid="meta_M_cpd15523_c0" sboTerm="SBO:0000247" id="M_cpd15523_c0" name="1,2-di-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C31H56O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15523_c0">
@@ -3889,7 +3889,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15702_c0" sboTerm="SBO:0000247" id="M_cpd15702_c0" name="1,2-Dianteisoheptadecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C37H72O5">
+      <species metaid="meta_M_cpd15702_c0" sboTerm="SBO:0000247" id="M_cpd15702_c0" name="1,2-di-14-methylhexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C37H72O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15702_c0">
@@ -3903,7 +3903,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15678_c0" sboTerm="SBO:0000247" id="M_cpd15678_c0" name="1,2-dianteisoheptadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C37H72O8P">
+      <species metaid="meta_M_cpd15678_c0" sboTerm="SBO:0000247" id="M_cpd15678_c0" name="1,2-di-14-methylhexadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C37H72O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15678_c0">
@@ -4292,7 +4292,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15422_c0" sboTerm="SBO:0000247" id="M_cpd15422_c0" name="CDP-1,2-ditetradec-7-enoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C40H67N3O15P2">
+      <species metaid="meta_M_cpd15422_c0" sboTerm="SBO:0000247" id="M_cpd15422_c0" name="CDP-1,2-di-(7Z)-tetradecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C40H67N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15422_c0">
@@ -4400,7 +4400,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15357_c0" sboTerm="SBO:0000247" id="M_cpd15357_c0" name="2-octadec-11-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C21H40O7P">
+      <species metaid="meta_M_cpd15357_c0" sboTerm="SBO:0000247" id="M_cpd15357_c0" name="2-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C21H40O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15357_c0">
@@ -4415,7 +4415,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15269_c0" sboTerm="SBO:0000247" id="M_cpd15269_c0" name="octadecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33O2">
+      <species metaid="meta_M_cpd15269_c0" sboTerm="SBO:0000247" id="M_cpd15269_c0" name="(11Z)-Octadecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15269_c0">
@@ -4466,7 +4466,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11492_c0" sboTerm="SBO:0000247" id="M_cpd11492_c0" name="Malonyl-acyl-carrierprotein- [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C14H24N2O10PRS">
+      <species metaid="meta_M_cpd11492_c0" sboTerm="SBO:0000247" id="M_cpd11492_c0" name="Malonyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C14H24N2O10PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11492_c0">
@@ -4485,7 +4485,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11486_c0" sboTerm="SBO:0000247" id="M_cpd11486_c0" name="3-Oxohexanoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C17H30N2O9PRS">
+      <species metaid="meta_M_cpd11486_c0" sboTerm="SBO:0000247" id="M_cpd11486_c0" name="3-Oxohexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C17H30N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11486_c0">
@@ -4578,7 +4578,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11522_c0" sboTerm="SBO:0000247" id="M_cpd11522_c0" name="5-methyl-3-hydroxy-hexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33N2O9PRS">
+      <species metaid="meta_M_cpd11522_c0" sboTerm="SBO:0000247" id="M_cpd11522_c0" name="(3R)-3-hydroxy-5-methylhexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11522_c0">
@@ -4592,7 +4592,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11523_c0" sboTerm="SBO:0000247" id="M_cpd11523_c0" name="5-methyl-trans-hex-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H31N2O8PRS">
+      <species metaid="meta_M_cpd11523_c0" sboTerm="SBO:0000247" id="M_cpd11523_c0" name="(2E)-5-methylhexenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H31N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11523_c0">
@@ -4626,7 +4626,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11421_c0" sboTerm="SBO:0000247" id="M_cpd11421_c0" name="trdrd [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H9NO2R2S2">
+      <species metaid="meta_M_cpd11421_c0" sboTerm="SBO:0000247" id="M_cpd11421_c0" name="Reduced thioredoxin [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H9NO2R2S2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11421_c0">
@@ -4683,7 +4683,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11420_c0" sboTerm="SBO:0000247" id="M_cpd11420_c0" name="trdox [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H7NO2R2S2">
+      <species metaid="meta_M_cpd11420_c0" sboTerm="SBO:0000247" id="M_cpd11420_c0" name="Oxidized thioredoxin [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C6H7NO2R2S2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11420_c0">
@@ -4805,7 +4805,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03189_c0" sboTerm="SBO:0000247" id="M_cpd03189_c0" name="3-Carboxy-1-hydroxypropyl-ThPP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C16H22N4O10P2S">
+      <species metaid="meta_M_cpd03189_c0" sboTerm="SBO:0000247" id="M_cpd03189_c0" name="3-Carboxy-1-hydroxypropyl-TPP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C16H22N4O10P2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03189_c0">
@@ -4841,7 +4841,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15239_c0" sboTerm="SBO:0000247" id="M_cpd15239_c0" name="Hexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H49N2O8PRS">
+      <species metaid="meta_M_cpd15239_c0" sboTerm="SBO:0000247" id="M_cpd15239_c0" name="(9Z)-Hexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H49N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15239_c0">
@@ -4856,7 +4856,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15418_c0" sboTerm="SBO:0000247" id="M_cpd15418_c0" name="CDP-1,2-dihexadec-9-enoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C44H75N3O15P2">
+      <species metaid="meta_M_cpd15418_c0" sboTerm="SBO:0000247" id="M_cpd15418_c0" name="CDP-1,2-di-(9Z)-hexadecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C44H75N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15418_c0">
@@ -5000,7 +5000,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00239_c0" sboTerm="SBO:0000247" id="M_cpd00239_c0" name="H2S [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="HS">
+      <species metaid="meta_M_cpd00239_c0" sboTerm="SBO:0000247" id="M_cpd00239_c0" name="Bisulfide (HS-) [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="HS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00239_c0">
@@ -5213,7 +5213,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00508_c0" sboTerm="SBO:0000247" id="M_cpd00508_c0" name="3MOP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H9O3">
+      <species metaid="meta_M_cpd00508_c0" sboTerm="SBO:0000247" id="M_cpd00508_c0" name="3-methyl-2-oxopentoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H9O3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00508_c0">
@@ -5511,7 +5511,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11490_c0" sboTerm="SBO:0000247" id="M_cpd11490_c0" name="3-oxooctanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H34N2O9PRS">
+      <species metaid="meta_M_cpd11490_c0" sboTerm="SBO:0000247" id="M_cpd11490_c0" name="3-Oxooctanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H34N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11490_c0">
@@ -5752,7 +5752,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11526_c0" sboTerm="SBO:0000247" id="M_cpd11526_c0" name="7-methyl-3-hydroxy-octanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H37N2O9PRS">
+      <species metaid="meta_M_cpd11526_c0" sboTerm="SBO:0000247" id="M_cpd11526_c0" name="(3R)-3-hydroxy-7-methyloctanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H37N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11526_c0">
@@ -5766,7 +5766,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11527_c0" sboTerm="SBO:0000247" id="M_cpd11527_c0" name="7-methyl-trans-oct-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H35N2O8PRS">
+      <species metaid="meta_M_cpd11527_c0" sboTerm="SBO:0000247" id="M_cpd11527_c0" name="(2E)-7-methyloctenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H35N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11527_c0">
@@ -6246,7 +6246,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11469_c0" sboTerm="SBO:0000247" id="M_cpd11469_c0" name="(2E)-Dodecenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H41N2O8PRS">
+      <species metaid="meta_M_cpd11469_c0" sboTerm="SBO:0000247" id="M_cpd11469_c0" name="(2E)-Dodecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H41N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11469_c0">
@@ -6418,7 +6418,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15328_c0" sboTerm="SBO:0000247" id="M_cpd15328_c0" name="1-octadec-11-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C21H40O7P">
+      <species metaid="meta_M_cpd15328_c0" sboTerm="SBO:0000247" id="M_cpd15328_c0" name="1-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C21H40O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15328_c0">
@@ -6471,7 +6471,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15687_c0" sboTerm="SBO:0000247" id="M_cpd15687_c0" name="CDP-1,2-dianteisopentadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C42H75N3O15P2">
+      <species metaid="meta_M_cpd15687_c0" sboTerm="SBO:0000247" id="M_cpd15687_c0" name="CDP-1,2-di-12-methyltetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C42H75N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15687_c0">
@@ -6725,7 +6725,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11478_c0" sboTerm="SBO:0000247" id="M_cpd11478_c0" name="(R)-3-Hydroxybutanoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C15H27N2O9PRS">
+      <species metaid="meta_M_cpd11478_c0" sboTerm="SBO:0000247" id="M_cpd11478_c0" name="(3R)-3-Hydroxybutanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C15H27N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11478_c0">
@@ -6741,7 +6741,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11465_c0" sboTerm="SBO:0000247" id="M_cpd11465_c0" name="But-2-enoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C15H25N2O8PRS">
+      <species metaid="meta_M_cpd11465_c0" sboTerm="SBO:0000247" id="M_cpd11465_c0" name="(2E)-Butenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C15H25N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11465_c0">
@@ -7059,7 +7059,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15539_c0" sboTerm="SBO:0000247" id="M_cpd15539_c0" name="Phosphatidylglycerol dihexadec-9-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H70O10P">
+      <species metaid="meta_M_cpd15539_c0" sboTerm="SBO:0000247" id="M_cpd15539_c0" name="1,2-di-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H70O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15539_c0">
@@ -7198,7 +7198,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00214_c0" sboTerm="SBO:0000247" id="M_cpd00214_c0" name="Palmitate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H31O2">
+      <species metaid="meta_M_cpd00214_c0" sboTerm="SBO:0000247" id="M_cpd00214_c0" name="Hexadecanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H31O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00214_c0">
@@ -7217,7 +7217,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11570_c0" sboTerm="SBO:0000247" id="M_cpd11570_c0" name="3-Oxooctodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O9PRS">
+      <species metaid="meta_M_cpd11570_c0" sboTerm="SBO:0000247" id="M_cpd11570_c0" name="3-Oxooctadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11570_c0">
@@ -7231,7 +7231,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11571_c0" sboTerm="SBO:0000247" id="M_cpd11571_c0" name="3-Hydroxyoctodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H55N2O9PRS">
+      <species metaid="meta_M_cpd11571_c0" sboTerm="SBO:0000247" id="M_cpd11571_c0" name="(3R)-3-Hydroxyoctadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H55N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11571_c0">
@@ -7320,7 +7320,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15679_c0" sboTerm="SBO:0000247" id="M_cpd15679_c0" name="1,2-diisotetradecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C31H60O8P">
+      <species metaid="meta_M_cpd15679_c0" sboTerm="SBO:0000247" id="M_cpd15679_c0" name="1,2-di-12-methyltridecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C31H60O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15679_c0">
@@ -7405,7 +7405,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15322_c0" sboTerm="SBO:0000247" id="M_cpd15322_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol hexadec-9-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H42O9P">
+      <species metaid="meta_M_cpd15322_c0" sboTerm="SBO:0000247" id="M_cpd15322_c0" name="1-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H42O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15322_c0">
@@ -7473,7 +7473,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15343_c0" sboTerm="SBO:0000247" id="M_cpd15343_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol dodecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O9P">
+      <species metaid="meta_M_cpd15343_c0" sboTerm="SBO:0000247" id="M_cpd15343_c0" name="2-dodecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15343_c0">
@@ -7734,7 +7734,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11484_c0" sboTerm="SBO:0000247" id="M_cpd11484_c0" name="HMA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H47N2O9PRS">
+      <species metaid="meta_M_cpd11484_c0" sboTerm="SBO:0000247" id="M_cpd11484_c0" name="(3R)-3-Hydroxytetradecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H47N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11484_c0">
@@ -7751,7 +7751,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11467_c0" sboTerm="SBO:0000247" id="M_cpd11467_c0" name="(2E)-Tetradecenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H45N2O8PRS">
+      <species metaid="meta_M_cpd11467_c0" sboTerm="SBO:0000247" id="M_cpd11467_c0" name="(2E)-Tetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H45N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11467_c0">
@@ -7835,7 +7835,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15704_c0" sboTerm="SBO:0000247" id="M_cpd15704_c0" name="1,2-Diisopentadecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C33H64O5">
+      <species metaid="meta_M_cpd15704_c0" sboTerm="SBO:0000247" id="M_cpd15704_c0" name="1,2-di-13-methyltetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C33H64O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15704_c0">
@@ -7849,7 +7849,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15680_c0" sboTerm="SBO:0000247" id="M_cpd15680_c0" name="1,2-diisopentadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C33H64O8P">
+      <species metaid="meta_M_cpd15680_c0" sboTerm="SBO:0000247" id="M_cpd15680_c0" name="1,2-di-13-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C33H64O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15680_c0">
@@ -8074,7 +8074,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11489_c0" sboTerm="SBO:0000247" id="M_cpd11489_c0" name="3-oxododecanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H42N2O9PRS">
+      <species metaid="meta_M_cpd11489_c0" sboTerm="SBO:0000247" id="M_cpd11489_c0" name="3-Oxododecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H42N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11489_c0">
@@ -8207,7 +8207,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11476_c0" sboTerm="SBO:0000247" id="M_cpd11476_c0" name="hexadecanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H51N2O8PRS">
+      <species metaid="meta_M_cpd11476_c0" sboTerm="SBO:0000247" id="M_cpd11476_c0" name="Hexadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H51N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11476_c0">
@@ -8223,7 +8223,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00134_c0" sboTerm="SBO:0000247" id="M_cpd00134_c0" name="Palmitoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C37H62N7O17P3S">
+      <species metaid="meta_M_cpd00134_c0" sboTerm="SBO:0000247" id="M_cpd00134_c0" name="Hexadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C37H62N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00134_c0">
@@ -8242,7 +8242,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15312_c0" sboTerm="SBO:0000247" id="M_cpd15312_c0" name="1,2-Diacyl-sn-glycerol dioctadec-11-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C39H72O5">
+      <species metaid="meta_M_cpd15312_c0" sboTerm="SBO:0000247" id="M_cpd15312_c0" name="1,2-di-(11Z)-octadecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C39H72O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15312_c0">
@@ -8257,7 +8257,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15527_c0" sboTerm="SBO:0000247" id="M_cpd15527_c0" name="1,2-dioctadec-11-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C39H72O8P">
+      <species metaid="meta_M_cpd15527_c0" sboTerm="SBO:0000247" id="M_cpd15527_c0" name="1,2-di-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C39H72O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15527_c0">
@@ -8433,7 +8433,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15420_c0" sboTerm="SBO:0000247" id="M_cpd15420_c0" name="CDP-1,2-dioctadec-11-enoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C48H83N3O15P2">
+      <species metaid="meta_M_cpd15420_c0" sboTerm="SBO:0000247" id="M_cpd15420_c0" name="CDP-1,2-di-(11Z)-octadecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C48H83N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15420_c0">
@@ -8498,7 +8498,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd01080_c0" sboTerm="SBO:0000247" id="M_cpd01080_c0" name="ocdca [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H35O2">
+      <species metaid="meta_M_cpd01080_c0" sboTerm="SBO:0000247" id="M_cpd01080_c0" name="Octadecanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H35O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd01080_c0">
@@ -8556,7 +8556,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11437_c0" sboTerm="SBO:0000247" id="M_cpd11437_c0" name="fa3coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C36H61N7O17P3S">
+      <species metaid="meta_M_cpd11437_c0" sboTerm="SBO:0000247" id="M_cpd11437_c0" name="13-Methyltetradecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C36H61N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11437_c0">
@@ -8570,7 +8570,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15674_c0" sboTerm="SBO:0000247" id="M_cpd15674_c0" name="1-isopentadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O7P">
+      <species metaid="meta_M_cpd15674_c0" sboTerm="SBO:0000247" id="M_cpd15674_c0" name="1-13-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15674_c0">
@@ -8584,7 +8584,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11491_c0" sboTerm="SBO:0000247" id="M_cpd11491_c0" name="3-oxotetradecanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H46N2O9PRS">
+      <species metaid="meta_M_cpd11491_c0" sboTerm="SBO:0000247" id="M_cpd11491_c0" name="3-Oxotetradecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C25H46N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11491_c0">
@@ -8696,7 +8696,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00327_c0" sboTerm="SBO:0000247" id="M_cpd00327_c0" name="strcoa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C39H66N7O17P3S">
+      <species metaid="meta_M_cpd00327_c0" sboTerm="SBO:0000247" id="M_cpd00327_c0" name="Octadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C39H66N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00327_c0">
@@ -8995,7 +8995,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15731_c0" sboTerm="SBO:0000247" id="M_cpd15731_c0" name="Diglucosyl-1,2 diisoheptadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C49H92O15">
+      <species metaid="meta_M_cpd15731_c0" sboTerm="SBO:0000247" id="M_cpd15731_c0" name="1,2-di-15-methylhexadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C49H92O15">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15731_c0">
@@ -9259,7 +9259,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15730_c0" sboTerm="SBO:0000247" id="M_cpd15730_c0" name="Diglucosyl-1,2 distearoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C51H96O15">
+      <species metaid="meta_M_cpd15730_c0" sboTerm="SBO:0000247" id="M_cpd15730_c0" name="1,2-dioctadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C51H96O15">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15730_c0">
@@ -9431,7 +9431,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03847_c0" sboTerm="SBO:0000247" id="M_cpd03847_c0" name="Myristic acid [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H27O2">
+      <species metaid="meta_M_cpd03847_c0" sboTerm="SBO:0000247" id="M_cpd03847_c0" name="Tetradecanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H27O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03847_c0">
@@ -9469,7 +9469,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11534_c0" sboTerm="SBO:0000247" id="M_cpd11534_c0" name="11-methyl-3-hydroxy-dodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H45N2O9PRS">
+      <species metaid="meta_M_cpd11534_c0" sboTerm="SBO:0000247" id="M_cpd11534_c0" name="(3R)-3-hydroxy-11-methyldodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H45N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11534_c0">
@@ -9483,7 +9483,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11535_c0" sboTerm="SBO:0000247" id="M_cpd11535_c0" name="11-methyl-trans-dodec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H43N2O8PRS">
+      <species metaid="meta_M_cpd11535_c0" sboTerm="SBO:0000247" id="M_cpd11535_c0" name="(2E)-11-methyldodecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H43N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11535_c0">
@@ -9616,7 +9616,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd02882_c0" sboTerm="SBO:0000247" id="M_cpd02882_c0" name="4--1-D-Ribitylamino-5-aminouracil [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C9H16N4O6">
+      <species metaid="meta_M_cpd02882_c0" sboTerm="SBO:0000247" id="M_cpd02882_c0" name="5-Amino-6-(1-D-ribitylamino)uracil [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C9H16N4O6">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd02882_c0">
@@ -9741,7 +9741,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11501_c0" sboTerm="SBO:0000247" id="M_cpd11501_c0" name="6-methyl-3-hydroxy-octanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H37N2O9PRS">
+      <species metaid="meta_M_cpd11501_c0" sboTerm="SBO:0000247" id="M_cpd11501_c0" name="(3R)-3-hydroxy-6-methyloctanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H37N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11501_c0">
@@ -9755,7 +9755,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11502_c0" sboTerm="SBO:0000247" id="M_cpd11502_c0" name="6-methyl-trans-oct-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H35N2O8PRS">
+      <species metaid="meta_M_cpd11502_c0" sboTerm="SBO:0000247" id="M_cpd11502_c0" name="(2E)-6-methyloctenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H35N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11502_c0">
@@ -9860,7 +9860,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00214_e0" sboTerm="SBO:0000247" id="M_cpd00214_e0" name="Palmitate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H31O2">
+      <species metaid="meta_M_cpd00214_e0" sboTerm="SBO:0000247" id="M_cpd00214_e0" name="Hexadecanoate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C16H31O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00214_e0">
@@ -9960,7 +9960,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11475_c0" sboTerm="SBO:0000247" id="M_cpd11475_c0" name="(2E)-Decenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
+      <species metaid="meta_M_cpd11475_c0" sboTerm="SBO:0000247" id="M_cpd11475_c0" name="(2E)-Decenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11475_c0">
@@ -10151,7 +10151,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15366_c0" sboTerm="SBO:0000247" id="M_cpd15366_c0" name="(R)-3-hydroxy-cis-dodec-5-enoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C23H41N2O9PRS">
+      <species metaid="meta_M_cpd15366_c0" sboTerm="SBO:0000247" id="M_cpd15366_c0" name="(3R,5Z)-3-Hydroxydodecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C23H41N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15366_c0">
@@ -10166,7 +10166,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15569_c0" sboTerm="SBO:0000247" id="M_cpd15569_c0" name="trans-3-cis-5-dodecenoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C23H39N2O8PRS">
+      <species metaid="meta_M_cpd15569_c0" sboTerm="SBO:0000247" id="M_cpd15569_c0" name="(3E,5Z)-Dodecadienoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C23H39N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15569_c0">
@@ -10237,7 +10237,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15684_c0" sboTerm="SBO:0000247" id="M_cpd15684_c0" name="CDP-1,2-dianteisoheptadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C46H83N3O15P2">
+      <species metaid="meta_M_cpd15684_c0" sboTerm="SBO:0000247" id="M_cpd15684_c0" name="CDP-1,2-di-14-methylhexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C46H83N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15684_c0">
@@ -10265,7 +10265,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11481_c0" sboTerm="SBO:0000247" id="M_cpd11481_c0" name="R-3-hydroxypalmitoyl-acyl-carrierprotein- [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H51N2O9PRS">
+      <species metaid="meta_M_cpd11481_c0" sboTerm="SBO:0000247" id="M_cpd11481_c0" name="(3R)-3-Hydroxyhexadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H51N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11481_c0">
@@ -10281,7 +10281,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11485_c0" sboTerm="SBO:0000247" id="M_cpd11485_c0" name="3-oxohexadecanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H50N2O9PRS">
+      <species metaid="meta_M_cpd11485_c0" sboTerm="SBO:0000247" id="M_cpd11485_c0" name="3-Oxohexadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H50N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11485_c0">
@@ -10592,7 +10592,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15323_c0" sboTerm="SBO:0000247" id="M_cpd15323_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol octadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H48O9P">
+      <species metaid="meta_M_cpd15323_c0" sboTerm="SBO:0000247" id="M_cpd15323_c0" name="1-octadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H48O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15323_c0">
@@ -10645,7 +10645,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15370_c0" sboTerm="SBO:0000247" id="M_cpd15370_c0" name="(R)-3-hydroxy-cis-vacc-11-enoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O9PRS">
+      <species metaid="meta_M_cpd15370_c0" sboTerm="SBO:0000247" id="M_cpd15370_c0" name="(3R,11Z)-3-Hydroxyoctadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15370_c0">
@@ -10660,7 +10660,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15568_c0" sboTerm="SBO:0000247" id="M_cpd15568_c0" name="trans-3-cis-11-vacceoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H51N2O8PRS">
+      <species metaid="meta_M_cpd15568_c0" sboTerm="SBO:0000247" id="M_cpd15568_c0" name="(3E,11Z)-Octadecadienoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H51N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15568_c0">
@@ -10689,7 +10689,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15330_c0" sboTerm="SBO:0000247" id="M_cpd15330_c0" name="1-tetradec-7-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H32O7P">
+      <species metaid="meta_M_cpd15330_c0" sboTerm="SBO:0000247" id="M_cpd15330_c0" name="1-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H32O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15330_c0">
@@ -10704,7 +10704,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15298_c0" sboTerm="SBO:0000247" id="M_cpd15298_c0" name="tetradecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H25O2">
+      <species metaid="meta_M_cpd15298_c0" sboTerm="SBO:0000247" id="M_cpd15298_c0" name="(7Z)-Tetradecenoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H25O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15298_c0">
@@ -10873,7 +10873,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15354_c0" sboTerm="SBO:0000247" id="M_cpd15354_c0" name="2-hexadec-9-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H36O7P">
+      <species metaid="meta_M_cpd15354_c0" sboTerm="SBO:0000247" id="M_cpd15354_c0" name="2-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H36O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15354_c0">
@@ -10908,7 +10908,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11517_c0" sboTerm="SBO:0000247" id="M_cpd11517_c0" name="14-methyl-3-hydroxy-hexa-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H53N2O9PRS">
+      <species metaid="meta_M_cpd11517_c0" sboTerm="SBO:0000247" id="M_cpd11517_c0" name="(3R)-3-hydroxy-14-methylhexadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H53N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11517_c0">
@@ -10922,7 +10922,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11518_c0" sboTerm="SBO:0000247" id="M_cpd11518_c0" name="14-methyl-trans-hexa-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H51N2O8PRS">
+      <species metaid="meta_M_cpd11518_c0" sboTerm="SBO:0000247" id="M_cpd11518_c0" name="(2E)-14-methylhexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H51N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11518_c0">
@@ -10936,7 +10936,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11480_c0" sboTerm="SBO:0000247" id="M_cpd11480_c0" name="D-3-Hydroxydodecanoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H43N2O9PRS">
+      <species metaid="meta_M_cpd11480_c0" sboTerm="SBO:0000247" id="M_cpd11480_c0" name="(3R)-3-Hydroxydodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C23H43N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11480_c0">
@@ -11243,7 +11243,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15538_c0" sboTerm="SBO:0000247" id="M_cpd15538_c0" name="Phosphatidylglycerol dihexadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H74O10P">
+      <species metaid="meta_M_cpd15538_c0" sboTerm="SBO:0000247" id="M_cpd15538_c0" name="1,2-dihexadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C38H74O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15538_c0">
@@ -11258,7 +11258,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15346_c0" sboTerm="SBO:0000247" id="M_cpd15346_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol hexadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H44O9P">
+      <species metaid="meta_M_cpd15346_c0" sboTerm="SBO:0000247" id="M_cpd15346_c0" name="2-hexadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H44O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15346_c0">
@@ -11405,7 +11405,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15733_c0" sboTerm="SBO:0000247" id="M_cpd15733_c0" name="Diglucosyl-1,2 diisotetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C43H80O15">
+      <species metaid="meta_M_cpd15733_c0" sboTerm="SBO:0000247" id="M_cpd15733_c0" name="1,2-di-12-methyltridecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C43H80O15">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15733_c0">
@@ -11670,7 +11670,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11542_c0" sboTerm="SBO:0000247" id="M_cpd11542_c0" name="15-methyl-3-hydroxy-hexa-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H53N2O9PRS">
+      <species metaid="meta_M_cpd11542_c0" sboTerm="SBO:0000247" id="M_cpd11542_c0" name="(3R)-3-hydroxy-15-methylhexadecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H53N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11542_c0">
@@ -11684,7 +11684,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11543_c0" sboTerm="SBO:0000247" id="M_cpd11543_c0" name="15-methyl-trans-hexa-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H51N2O8PRS">
+      <species metaid="meta_M_cpd11543_c0" sboTerm="SBO:0000247" id="M_cpd11543_c0" name="(2E)-15-methylhexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C28H51N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11543_c0">
@@ -11747,7 +11747,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11434_c0" sboTerm="SBO:0000247" id="M_cpd11434_c0" name="fa12coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C38H65N7O17P3S">
+      <species metaid="meta_M_cpd11434_c0" sboTerm="SBO:0000247" id="M_cpd11434_c0" name="14-Methylhexadecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C38H65N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11434_c0">
@@ -12019,7 +12019,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15369_c0" sboTerm="SBO:0000247" id="M_cpd15369_c0" name="(R)-3-hydroxy-cis-palm-9-eoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H49N2O9PRS">
+      <species metaid="meta_M_cpd15369_c0" sboTerm="SBO:0000247" id="M_cpd15369_c0" name="(3R,9Z)-3-Hydroxyhexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H49N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15369_c0">
@@ -12034,7 +12034,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15571_c0" sboTerm="SBO:0000247" id="M_cpd15571_c0" name="trans-3-cis-9-palmitoleoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H47N2O8PRS">
+      <species metaid="meta_M_cpd15571_c0" sboTerm="SBO:0000247" id="M_cpd15571_c0" name="(3E,9Z)-Hexadecadienoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C27H47N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15571_c0">
@@ -12151,7 +12151,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15540_c0" sboTerm="SBO:0000247" id="M_cpd15540_c0" name="Phosphatidylglycerol dioctadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C42H82O10P">
+      <species metaid="meta_M_cpd15540_c0" sboTerm="SBO:0000247" id="M_cpd15540_c0" name="1,2-dioctadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C42H82O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15540_c0">
@@ -12185,7 +12185,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15348_c0" sboTerm="SBO:0000247" id="M_cpd15348_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol octadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H48O9P">
+      <species metaid="meta_M_cpd15348_c0" sboTerm="SBO:0000247" id="M_cpd15348_c0" name="2-octadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H48O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15348_c0">
@@ -12234,7 +12234,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15537_c0" sboTerm="SBO:0000247" id="M_cpd15537_c0" name="Phosphatidylglycerol ditetradec-7-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H62O10P">
+      <species metaid="meta_M_cpd15537_c0" sboTerm="SBO:0000247" id="M_cpd15537_c0" name="1,2-di-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H62O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15537_c0">
@@ -12249,7 +12249,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15320_c0" sboTerm="SBO:0000247" id="M_cpd15320_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol tetradec-7-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H38O9P">
+      <species metaid="meta_M_cpd15320_c0" sboTerm="SBO:0000247" id="M_cpd15320_c0" name="1-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H38O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15320_c0">
@@ -12302,7 +12302,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11482_c0" sboTerm="SBO:0000247" id="M_cpd11482_c0" name="(R)-3-Hydroxydecanoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H40N2O9PRS">
+      <species metaid="meta_M_cpd11482_c0" sboTerm="SBO:0000247" id="M_cpd11482_c0" name="(3R)-3-Hydroxydecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H40N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11482_c0">
@@ -12319,7 +12319,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11487_c0" sboTerm="SBO:0000247" id="M_cpd11487_c0" name="3-oxodecanoyl-acp [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H38N2O9PRS">
+      <species metaid="meta_M_cpd11487_c0" sboTerm="SBO:0000247" id="M_cpd11487_c0" name="3-Oxodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H38N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11487_c0">
@@ -12369,7 +12369,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15722_c0" sboTerm="SBO:0000247" id="M_cpd15722_c0" name="Diisoheptadecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C40H78O10P">
+      <species metaid="meta_M_cpd15722_c0" sboTerm="SBO:0000247" id="M_cpd15722_c0" name="1,2-di-15-methylhexadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C40H78O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15722_c0">
@@ -12383,7 +12383,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15525_c0" sboTerm="SBO:0000247" id="M_cpd15525_c0" name="1,2-dihexadec-9-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C35H64O8P">
+      <species metaid="meta_M_cpd15525_c0" sboTerm="SBO:0000247" id="M_cpd15525_c0" name="1,2-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C35H64O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15525_c0">
@@ -12455,7 +12455,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15681_c0" sboTerm="SBO:0000247" id="M_cpd15681_c0" name="1,2-dianteisopentadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C33H64O8P">
+      <species metaid="meta_M_cpd15681_c0" sboTerm="SBO:0000247" id="M_cpd15681_c0" name="1,2-di-12-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C33H64O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15681_c0">
@@ -12469,7 +12469,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11479_c0" sboTerm="SBO:0000247" id="M_cpd11479_c0" name="D-3-Hydroxyhexanoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C17H31N2O9PRS">
+      <species metaid="meta_M_cpd11479_c0" sboTerm="SBO:0000247" id="M_cpd11479_c0" name="(3R)-3-Hydroxyhexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C17H31N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11479_c0">
@@ -12746,7 +12746,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15706_c0" sboTerm="SBO:0000247" id="M_cpd15706_c0" name="1,2-Diisohexadecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C35H68O5">
+      <species metaid="meta_M_cpd15706_c0" sboTerm="SBO:0000247" id="M_cpd15706_c0" name="1,2-di-14-methylpentadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C35H68O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15706_c0">
@@ -12760,7 +12760,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15345_c0" sboTerm="SBO:0000247" id="M_cpd15345_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol tetradec-7-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H38O9P">
+      <species metaid="meta_M_cpd15345_c0" sboTerm="SBO:0000247" id="M_cpd15345_c0" name="2-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H38O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15345_c0">
@@ -12832,7 +12832,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15311_c0" sboTerm="SBO:0000247" id="M_cpd15311_c0" name="1,2-Diacyl-sn-glycerol dioctadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C39H76O5">
+      <species metaid="meta_M_cpd15311_c0" sboTerm="SBO:0000247" id="M_cpd15311_c0" name="1,2-dioctadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C39H76O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15311_c0">
@@ -13360,7 +13360,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15344_c0" sboTerm="SBO:0000247" id="M_cpd15344_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol tetradecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O9P">
+      <species metaid="meta_M_cpd15344_c0" sboTerm="SBO:0000247" id="M_cpd15344_c0" name="2-tetradecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15344_c0">
@@ -13535,7 +13535,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03584_c0" sboTerm="SBO:0000247" id="M_cpd03584_c0" name="UDP-3-O-(beta-hydroxymyristoyl)-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H50N3O18P2">
+      <species metaid="meta_M_cpd03584_c0" sboTerm="SBO:0000247" id="M_cpd03584_c0" name="UDP-3-O-(3-hydroxytetradecanoyl)-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H50N3O18P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03584_c0">
@@ -13612,7 +13612,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00200_c0" sboTerm="SBO:0000247" id="M_cpd00200_c0" name="4MOP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H9O3">
+      <species metaid="meta_M_cpd00200_c0" sboTerm="SBO:0000247" id="M_cpd00200_c0" name="4-Methyl-2-oxopentanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H9O3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00200_c0">
@@ -13892,7 +13892,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11825_c0" sboTerm="SBO:0000247" id="M_cpd11825_c0" name="Octadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O8PRS">
+      <species metaid="meta_M_cpd11825_c0" sboTerm="SBO:0000247" id="M_cpd11825_c0" name="(11Z)-Octadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11825_c0">
@@ -13908,7 +13908,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15726_c0" sboTerm="SBO:0000247" id="M_cpd15726_c0" name="Dianteisopentadecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C36H70O10P">
+      <species metaid="meta_M_cpd15726_c0" sboTerm="SBO:0000247" id="M_cpd15726_c0" name="1,2-di-12-methyltetradecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C36H70O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15726_c0">
@@ -13979,7 +13979,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11538_c0" sboTerm="SBO:0000247" id="M_cpd11538_c0" name="13-methyl-3-hydroxy-tetra-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H49N2O9PRS">
+      <species metaid="meta_M_cpd11538_c0" sboTerm="SBO:0000247" id="M_cpd11538_c0" name="(3R)-3-hydroxy-13-methyltetradecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H49N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11538_c0">
@@ -13993,7 +13993,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11539_c0" sboTerm="SBO:0000247" id="M_cpd11539_c0" name="13-methyl-trans-tetra-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H47N2O8PRS">
+      <species metaid="meta_M_cpd11539_c0" sboTerm="SBO:0000247" id="M_cpd11539_c0" name="(2E)-13-methyltetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C26H47N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11539_c0">
@@ -14066,7 +14066,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15701_c0" sboTerm="SBO:0000247" id="M_cpd15701_c0" name="1,2-Diisoheptadecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C37H72O5">
+      <species metaid="meta_M_cpd15701_c0" sboTerm="SBO:0000247" id="M_cpd15701_c0" name="1,2-di-15-methylhexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C37H72O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15701_c0">
@@ -14080,7 +14080,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15677_c0" sboTerm="SBO:0000247" id="M_cpd15677_c0" name="1,2-diisoheptadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C37H72O8P">
+      <species metaid="meta_M_cpd15677_c0" sboTerm="SBO:0000247" id="M_cpd15677_c0" name="1,2-di-15-methylhexadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C37H72O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15677_c0">
@@ -14094,7 +14094,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11435_c0" sboTerm="SBO:0000247" id="M_cpd11435_c0" name="fa1coa [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C35H59N7O17P3S">
+      <species metaid="meta_M_cpd11435_c0" sboTerm="SBO:0000247" id="M_cpd11435_c0" name="12-Methyltridecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C35H59N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11435_c0">
@@ -14108,7 +14108,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15673_c0" sboTerm="SBO:0000247" id="M_cpd15673_c0" name="1-isotetradecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H34O7P">
+      <species metaid="meta_M_cpd15673_c0" sboTerm="SBO:0000247" id="M_cpd15673_c0" name="1-12-methyltridecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H34O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15673_c0">
@@ -14213,7 +14213,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00342_c0" sboTerm="SBO:0000247" id="M_cpd00342_c0" name="N-Acetylornithine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C7H14N2O3">
+      <species metaid="meta_M_cpd00342_c0" sboTerm="SBO:0000247" id="M_cpd00342_c0" name="N-acetylornithine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C7H14N2O3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00342_c0">
@@ -14266,7 +14266,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15723_c0" sboTerm="SBO:0000247" id="M_cpd15723_c0" name="Dianteisoheptadecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C40H78O10P">
+      <species metaid="meta_M_cpd15723_c0" sboTerm="SBO:0000247" id="M_cpd15723_c0" name="1,2-di-14-methylhexadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C40H78O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15723_c0">
@@ -14391,7 +14391,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11509_c0" sboTerm="SBO:0000247" id="M_cpd11509_c0" name="10-methyl-3-hydroxy-dodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H45N2O9PRS">
+      <species metaid="meta_M_cpd11509_c0" sboTerm="SBO:0000247" id="M_cpd11509_c0" name="(3R)-3-hydroxy-10-methyldodecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H45N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11509_c0">
@@ -14405,7 +14405,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11510_c0" sboTerm="SBO:0000247" id="M_cpd11510_c0" name="10-methyl-trans-dodec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H43N2O8PRS">
+      <species metaid="meta_M_cpd11510_c0" sboTerm="SBO:0000247" id="M_cpd11510_c0" name="(2E)-10-methyldodecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H43N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11510_c0">
@@ -14419,7 +14419,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15349_c0" sboTerm="SBO:0000247" id="M_cpd15349_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol octadec-11-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H46O9P">
+      <species metaid="meta_M_cpd15349_c0" sboTerm="SBO:0000247" id="M_cpd15349_c0" name="2-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H46O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15349_c0">
@@ -14434,7 +14434,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11473_c0" sboTerm="SBO:0000247" id="M_cpd11473_c0" name="(2E)-Hexenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H29N2O8PRS">
+      <species metaid="meta_M_cpd11473_c0" sboTerm="SBO:0000247" id="M_cpd11473_c0" name="(2E)-Hexenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H29N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11473_c0">
@@ -14560,7 +14560,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15536_c0" sboTerm="SBO:0000247" id="M_cpd15536_c0" name="Phosphatidylglycerol ditetradecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H66O10P">
+      <species metaid="meta_M_cpd15536_c0" sboTerm="SBO:0000247" id="M_cpd15536_c0" name="1,2-ditetradecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H66O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15536_c0">
@@ -14677,7 +14677,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15321_c0" sboTerm="SBO:0000247" id="M_cpd15321_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol hexadecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H44O9P">
+      <species metaid="meta_M_cpd15321_c0" sboTerm="SBO:0000247" id="M_cpd15321_c0" name="1-hexadecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H44O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15321_c0">
@@ -14768,7 +14768,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15676_c0" sboTerm="SBO:0000247" id="M_cpd15676_c0" name="1-isohexadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H38O7P">
+      <species metaid="meta_M_cpd15676_c0" sboTerm="SBO:0000247" id="M_cpd15676_c0" name="1-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H38O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15676_c0">
@@ -14820,7 +14820,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd02886_c0" sboTerm="SBO:0000247" id="M_cpd02886_c0" name="UDP-3-O-(beta-hydroxymyristoyl)-N-acetylglucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C31H51N3O19P2">
+      <species metaid="meta_M_cpd02886_c0" sboTerm="SBO:0000247" id="M_cpd02886_c0" name="UDP-3-O-(3-hydroxytetradecanoyl)-N-acetylglucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C31H51N3O19P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd02886_c0">
@@ -14877,7 +14877,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15705_c0" sboTerm="SBO:0000247" id="M_cpd15705_c0" name="1,2-Dianteisopentadecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C33H64O5">
+      <species metaid="meta_M_cpd15705_c0" sboTerm="SBO:0000247" id="M_cpd15705_c0" name="1,2-di-12-methyltetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C33H64O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15705_c0">
@@ -14968,7 +14968,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15735_c0" sboTerm="SBO:0000247" id="M_cpd15735_c0" name="Diglucosyl-1,2 dianteisopentadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C45H84O15">
+      <species metaid="meta_M_cpd15735_c0" sboTerm="SBO:0000247" id="M_cpd15735_c0" name="1,2-di-12-methyltetradecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C45H84O15">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15735_c0">
@@ -15117,7 +15117,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11530_c0" sboTerm="SBO:0000247" id="M_cpd11530_c0" name="9-methyl-3-hydroxy-decanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H41N2O9PRS">
+      <species metaid="meta_M_cpd11530_c0" sboTerm="SBO:0000247" id="M_cpd11530_c0" name="(3R)-3-hydroxy-9-methyldecanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H41N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11530_c0">
@@ -15131,7 +15131,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11531_c0" sboTerm="SBO:0000247" id="M_cpd11531_c0" name="9-methyl-trans-dec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H39N2O8PRS">
+      <species metaid="meta_M_cpd11531_c0" sboTerm="SBO:0000247" id="M_cpd11531_c0" name="(2E)-9-methyldecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H39N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11531_c0">
@@ -15145,7 +15145,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15732_c0" sboTerm="SBO:0000247" id="M_cpd15732_c0" name="Diglucosyl-1,2 dianteisoheptadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C49H92O15">
+      <species metaid="meta_M_cpd15732_c0" sboTerm="SBO:0000247" id="M_cpd15732_c0" name="1,2-di-14-methylhexadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C49H92O15">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15732_c0">
@@ -15421,7 +15421,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd03847_e0" sboTerm="SBO:0000247" id="M_cpd03847_e0" name="Myristic acid [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H27O2">
+      <species metaid="meta_M_cpd03847_e0" sboTerm="SBO:0000247" id="M_cpd03847_e0" name="Tetradecanoate [c0] [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C14H27O2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd03847_e0">
@@ -15690,7 +15690,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15535_c0" sboTerm="SBO:0000247" id="M_cpd15535_c0" name="Phosphatidylglycerol didodecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C30H58O10P">
+      <species metaid="meta_M_cpd15535_c0" sboTerm="SBO:0000247" id="M_cpd15535_c0" name="1,2-didodecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C30H58O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15535_c0">
@@ -15744,7 +15744,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15318_c0" sboTerm="SBO:0000247" id="M_cpd15318_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol dodecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O9P">
+      <species metaid="meta_M_cpd15318_c0" sboTerm="SBO:0000247" id="M_cpd15318_c0" name="1-dodecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H36O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15318_c0">
@@ -15759,7 +15759,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11572_c0" sboTerm="SBO:0000247" id="M_cpd11572_c0" name="trans-Octodec-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O8PRS">
+      <species metaid="meta_M_cpd11572_c0" sboTerm="SBO:0000247" id="M_cpd11572_c0" name="(2E)-Octadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C29H53N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11572_c0">
@@ -15802,7 +15802,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15724_c0" sboTerm="SBO:0000247" id="M_cpd15724_c0" name="Diisotetradecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H66O10P">
+      <species metaid="meta_M_cpd15724_c0" sboTerm="SBO:0000247" id="M_cpd15724_c0" name="1,2-di-12-methyltridecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C34H66O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15724_c0">
@@ -15816,7 +15816,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15683_c0" sboTerm="SBO:0000247" id="M_cpd15683_c0" name="CDP-1,2-diisoheptadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C46H83N3O15P2">
+      <species metaid="meta_M_cpd15683_c0" sboTerm="SBO:0000247" id="M_cpd15683_c0" name="CDP-1,2-di-15-methylhexadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C46H83N3O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15683_c0">
@@ -16022,7 +16022,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd08210_c0" sboTerm="SBO:0000247" id="M_cpd08210_c0" name="ADC [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C10H10NO5">
+      <species metaid="meta_M_cpd08210_c0" sboTerm="SBO:0000247" id="M_cpd08210_c0" name="4-amino-4-deoxychorismate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C10H10NO5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd08210_c0">
@@ -16326,7 +16326,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15294_c0" sboTerm="SBO:0000247" id="M_cpd15294_c0" name="Tetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H45N2O8PRS">
+      <species metaid="meta_M_cpd15294_c0" sboTerm="SBO:0000247" id="M_cpd15294_c0" name="(7Z)-Tetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H45N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15294_c0">
@@ -16360,7 +16360,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15672_c0" sboTerm="SBO:0000247" id="M_cpd15672_c0" name="1-anteisoheptadecanoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O7P">
+      <species metaid="meta_M_cpd15672_c0" sboTerm="SBO:0000247" id="M_cpd15672_c0" name="1-13-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15672_c0">
@@ -16482,7 +16482,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15734_c0" sboTerm="SBO:0000247" id="M_cpd15734_c0" name="Diglucosyl-1,2 diisopentadecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C45H84O15">
+      <species metaid="meta_M_cpd15734_c0" sboTerm="SBO:0000247" id="M_cpd15734_c0" name="1,2-di-13-methyltetradecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C45H84O15">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15734_c0">
@@ -16605,7 +16605,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11477_c0" sboTerm="SBO:0000247" id="M_cpd11477_c0" name="(2E)-Hexadecenoyl-[acp] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H49N2O8PRS">
+      <species metaid="meta_M_cpd11477_c0" sboTerm="SBO:0000247" id="M_cpd11477_c0" name="(2E)-Hexadecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C27H49N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11477_c0">
@@ -16622,7 +16622,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11497_c0" sboTerm="SBO:0000247" id="M_cpd11497_c0" name="4-methyl-3-hydroxy-hexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33N2O9PRS">
+      <species metaid="meta_M_cpd11497_c0" sboTerm="SBO:0000247" id="M_cpd11497_c0" name="(3R)-3-hydroxy-4-methylhexanoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H33N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11497_c0">
@@ -16636,7 +16636,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11498_c0" sboTerm="SBO:0000247" id="M_cpd11498_c0" name="4-methyl-trans-hex-2-enoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H31N2O8PRS">
+      <species metaid="meta_M_cpd11498_c0" sboTerm="SBO:0000247" id="M_cpd11498_c0" name="(2E)-4-methylhexenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H31N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd11498_c0">
@@ -17033,7 +17033,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15326_c0" sboTerm="SBO:0000247" id="M_cpd15326_c0" name="1-hexadec-9-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H36O7P">
+      <species metaid="meta_M_cpd15326_c0" sboTerm="SBO:0000247" id="M_cpd15326_c0" name="1-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C19H36O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15326_c0">
@@ -17091,7 +17091,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15319_c0" sboTerm="SBO:0000247" id="M_cpd15319_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol tetradecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O9P">
+      <species metaid="meta_M_cpd15319_c0" sboTerm="SBO:0000247" id="M_cpd15319_c0" name="1-tetradecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C20H40O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15319_c0">
@@ -17160,7 +17160,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15362_c0" sboTerm="SBO:0000247" id="M_cpd15362_c0" name="2-tetradec-7-enoyl-sn-glycerol 3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H32O7P">
+      <species metaid="meta_M_cpd15362_c0" sboTerm="SBO:0000247" id="M_cpd15362_c0" name="2-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C17H32O7P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15362_c0">
@@ -17258,7 +17258,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15306_c0" sboTerm="SBO:0000247" id="M_cpd15306_c0" name="1,2-Diacyl-sn-glycerol didodecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C27H52O5">
+      <species metaid="meta_M_cpd15306_c0" sboTerm="SBO:0000247" id="M_cpd15306_c0" name="1,2-didodecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C27H52O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15306_c0">
@@ -17420,7 +17420,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00461_c0" sboTerm="SBO:0000247" id="M_cpd00461_c0" name="Oxopent-4-enoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C5H5O3">
+      <species metaid="meta_M_cpd00461_c0" sboTerm="SBO:0000247" id="M_cpd00461_c0" name="2-Hydroxy-2,4-pentadienoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C5H5O3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00461_c0">
@@ -17624,7 +17624,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15729_c0" sboTerm="SBO:0000247" id="M_cpd15729_c0" name="Diglucosyl-1,2 dimyristoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C43H80O15">
+      <species metaid="meta_M_cpd15729_c0" sboTerm="SBO:0000247" id="M_cpd15729_c0" name="1,2-ditetradecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C43H80O15">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15729_c0">
@@ -18028,7 +18028,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15368_c0" sboTerm="SBO:0000247" id="M_cpd15368_c0" name="(R)-3-hydroxy-cis-myristol-7-eoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H45N2O9PRS">
+      <species metaid="meta_M_cpd15368_c0" sboTerm="SBO:0000247" id="M_cpd15368_c0" name="(3R,7Z)-3-Hydroxytetradecenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H45N2O9PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15368_c0">
@@ -18043,7 +18043,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15570_c0" sboTerm="SBO:0000247" id="M_cpd15570_c0" name="trans-3-cis-7-myristoleoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H43N2O8PRS">
+      <species metaid="meta_M_cpd15570_c0" sboTerm="SBO:0000247" id="M_cpd15570_c0" name="(3E,7Z)-Tetradecadienoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C25H43N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15570_c0">
@@ -18077,7 +18077,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15728_c0" sboTerm="SBO:0000247" id="M_cpd15728_c0" name="Diglucosyl-1,2 dipalmitoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C47H88O15">
+      <species metaid="meta_M_cpd15728_c0" sboTerm="SBO:0000247" id="M_cpd15728_c0" name="1,2-dihexadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C47H88O15">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15728_c0">
@@ -18338,7 +18338,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15541_c0" sboTerm="SBO:0000247" id="M_cpd15541_c0" name="Phosphatidylglycerol dioctadec-11-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C42H78O10P">
+      <species metaid="meta_M_cpd15541_c0" sboTerm="SBO:0000247" id="M_cpd15541_c0" name="1,2-di-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C42H78O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15541_c0">
@@ -18475,7 +18475,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15725_c0" sboTerm="SBO:0000247" id="M_cpd15725_c0" name="Diisopentadecanoylphosphatidylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C36H70O10P">
+      <species metaid="meta_M_cpd15725_c0" sboTerm="SBO:0000247" id="M_cpd15725_c0" name="1,2-di-13-methyltetradecanoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C36H70O10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15725_c0">
@@ -18507,7 +18507,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15324_c0" sboTerm="SBO:0000247" id="M_cpd15324_c0" name="1-Acyl-sn-glycero-3-phosphoglycerol octadec-11-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H46O9P">
+      <species metaid="meta_M_cpd15324_c0" sboTerm="SBO:0000247" id="M_cpd15324_c0" name="1-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C24H46O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15324_c0">
@@ -18543,7 +18543,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15703_c0" sboTerm="SBO:0000247" id="M_cpd15703_c0" name="1,2-Diisotetradecanoyl-sn-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H60O5">
+      <species metaid="meta_M_cpd15703_c0" sboTerm="SBO:0000247" id="M_cpd15703_c0" name="1,2-di-12-methyltridecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H60O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15703_c0">
@@ -18681,7 +18681,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15347_c0" sboTerm="SBO:0000247" id="M_cpd15347_c0" name="2-Acyl-sn-glycero-3-phosphoglycerol hexadec-9-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H42O9P">
+      <species metaid="meta_M_cpd15347_c0" sboTerm="SBO:0000247" id="M_cpd15347_c0" name="2-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H42O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15347_c0">
@@ -18749,7 +18749,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15307_c0" sboTerm="SBO:0000247" id="M_cpd15307_c0" name="1,2-Diacyl-sn-glycerol ditetradecanoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H60O5">
+      <species metaid="meta_M_cpd15307_c0" sboTerm="SBO:0000247" id="M_cpd15307_c0" name="1,2-ditetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H60O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15307_c0">
@@ -18833,7 +18833,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15310_c0" sboTerm="SBO:0000247" id="M_cpd15310_c0" name="1,2-Diacyl-sn-glycerol dihexadec-9-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C35H64O5">
+      <species metaid="meta_M_cpd15310_c0" sboTerm="SBO:0000247" id="M_cpd15310_c0" name="1,2-di-(9Z)-hexadecenoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C35H64O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd15310_c0">
@@ -18935,7 +18935,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd21088_c0" sboTerm="SBO:0000247" id="M_cpd21088_c0" name="Pimelyl-[acyl-carrier protein] methyl ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C8H13O3RS">
+      <species metaid="meta_M_cpd21088_c0" sboTerm="SBO:0000247" id="M_cpd21088_c0" name="Pimeloyl-ACP methyl ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C8H13O3RS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd21088_c0">
@@ -18951,7 +18951,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd21087_c0" sboTerm="SBO:0000247" id="M_cpd21087_c0" name="Pimelyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C7H11O3RS">
+      <species metaid="meta_M_cpd21087_c0" sboTerm="SBO:0000247" id="M_cpd21087_c0" name="Pimeloyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C7H11O3RS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd21087_c0">
@@ -19059,7 +19059,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd12489_c0" sboTerm="SBO:0000247" id="M_cpd12489_c0" name="cis-3-Decenoyl-[acyl-carrier protein] [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
+      <species metaid="meta_M_cpd12489_c0" sboTerm="SBO:0000247" id="M_cpd12489_c0" name="(3Z)-Decenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd12489_c0">
@@ -19111,7 +19111,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd36635_c0" sboTerm="SBO:0000247" id="M_cpd36635_c0" name="Malonyl-acp-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C18H30N3O11PR2S">
+      <species metaid="meta_M_cpd36635_c0" sboTerm="SBO:0000247" id="M_cpd36635_c0" name="Malonyl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C18H30N3O11PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd36635_c0">
@@ -19125,7 +19125,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd22028_c0" sboTerm="SBO:0000247" id="M_cpd22028_c0" name="3-Ketopimeloyl-ACP-methyl-esters [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H36N3O12PR2S">
+      <species metaid="meta_M_cpd22028_c0" sboTerm="SBO:0000247" id="M_cpd22028_c0" name="3-Ketopimeloyl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H36N3O12PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd22028_c0">
@@ -19140,7 +19140,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd22065_c0" sboTerm="SBO:0000247" id="M_cpd22065_c0" name="3-hydroxypimeloyl-ACP-methyl-esters [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H38N3O12PR2S">
+      <species metaid="meta_M_cpd22065_c0" sboTerm="SBO:0000247" id="M_cpd22065_c0" name="(3R)-3-Hydroxypimeloyl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H38N3O12PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd22065_c0">
@@ -19549,7 +19549,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd27021_c0" sboTerm="SBO:0000247" id="M_cpd27021_c0" name="Enoylpimeloyl-ACP-methyl-esters [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H36N3O11PR2S">
+      <species metaid="meta_M_cpd27021_c0" sboTerm="SBO:0000247" id="M_cpd27021_c0" name="(2E)-Enoylpimeloyl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H36N3O11PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd27021_c0">
@@ -19690,7 +19690,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd27020_c0" sboTerm="SBO:0000247" id="M_cpd27020_c0" name="Enoylglutaryl-ACP-methyl-esters [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C20H32N3O11PR2S">
+      <species metaid="meta_M_cpd27020_c0" sboTerm="SBO:0000247" id="M_cpd27020_c0" name="(2E)-Enoylglutaryl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C20H32N3O11PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd27020_c0">
@@ -20298,7 +20298,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd27180_c0" sboTerm="SBO:0000247" id="M_cpd27180_c0" name="Glutaryl-ACP-methyl-esters [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C20H34N3O11PR2S">
+      <species metaid="meta_M_cpd27180_c0" sboTerm="SBO:0000247" id="M_cpd27180_c0" name="Glutaryl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C20H34N3O11PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd27180_c0">
@@ -20810,7 +20810,7 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00239_e0" sboTerm="SBO:0000247" id="M_cpd00239_e0" name="H2S [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="HS">
+      <species metaid="meta_M_cpd00239_e0" sboTerm="SBO:0000247" id="M_cpd00239_e0" name="Bisulfide (HS-) [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="HS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_M_cpd00239_e0">


### PR DESCRIPTION
This pull request:

- Changes name of `cpd00443_c0` from ABEE [c0] to 4-aminobenzoate [c0]
- Changes name of `cpd11441_c0` from fa6coa [c0] to 14-Methylpentadecanoyl-CoA [c0]
- Changes name of `cpd03049_c0` from 2-Hydroxyethyl-ThPP [c0] to 2-Hydroxyethyl-TPP [c0]
- Changes name of `cpd15736_c0` from Diglucosyl-1,2 diisohexadecanoylglycerol [c0] to 1,2-di-14-methylpentadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]
- Changes name of `cpd03114_c0` from 3-Oxopalmitoyl-CoA [c0] to 3-Oxohexadecanoyl-CoA [c0]
- Changes name of `cpd11466_c0` from Myristoyl-ACP [c0] to Tetradecanoyl-ACP [c0]
- Changes name of `cpd01695_c0` from Myristoyl-CoA [c0] to Tetradecanoyl-CoA [c0]
- Changes name of `cpd15688_c0` from CDP-1,2-diisohexadecanoylglycerol [c0] to CDP-1,2-di-14-methylpentadecanoylglycerol [c0]
- Changes name of `cpd15727_c0` from Diisohexadecanoylphosphatidylglycerol [c0] to 1,2-di-14-methylpentadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd00193_c0` from APS [c0] to 5'-Adenylyl sulfate [c0]
- Changes name of `cpd15237_c0` from hexadecenoate [c0] to (9Z)-Hexadecenoate [c0]
- Changes name of `cpd15686_c0` from CDP-1,2-diisopentadecanoylglycerol [c0] to CDP-1,2-di-13-methyltetradecanoylglycerol [c0]
- Changes name of `cpd11439_c0` from fa4coa [c0] to 12-Methyltetradecanoyl-CoA [c0]
- Changes name of `cpd15675_c0` from 1-anteisopentadecanoyl-sn-glycerol 3-phosphate [c0] to 1-12-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15682_c0` from 1,2-diisohexadecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11483_c0` from (R)-3-Hydroxyoctanoyl-[acyl-carrier protein] [c0] to (3R)-3-Hydroxyoctanoyl-ACP [c0]
- Changes name of `cpd11471_c0` from (2E)-Octenoyl-[acp] [c0] to (2E)-Octenoyl-ACP [c0]
- Changes name of `cpd11432_c0` from fa11coa [c0] to 15-Methylhexadecanoyl-CoA [c0]
- Changes name of `cpd15671_c0` from 1-isoheptadecanoyl-sn-glycerol 3-phosphate [c0] to 1-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11513_c0` from 12-methyl-3-hydroxy-tetra-decanoyl-ACP [c0] to (3R)-3-hydroxy-12-methyltetradecanoyl-ACP [c0]
- Changes name of `cpd11514_c0` from 12-methyl-trans-tetra-dec-2-enoyl-ACP [c0] to (2E)-12-methyltetradecenoyl-ACP [c0]
- Changes name of `cpd15685_c0` from CDP-1,2-diisotetradecanoylglycerol [c0] to CDP-1,2-di-12-methyltridecanoylglycerol [c0]
- Changes name of `cpd11505_c0` from 8-methyl-3-hydroxy-decanoyl-ACP [c0] to (3R)-3-hydroxy-8-methyldecanoyl-ACP [c0]
- Changes name of `cpd11506_c0` from 8-methyl-trans-dec-2-enoyl-ACP [c0] to (2E)-8-methyldecenoyl-ACP [c0]
- Changes name of `cpd01741_c0` from ddca [c0] to Dodecanoate [c0]
- Changes name of `cpd15308_c0` from 1,2-Diacyl-sn-glycerol ditetradec-7-enoyl [c0] to 1,2-di-(7Z)-tetradecenoylglycerol [c0]
- Changes name of `cpd15523_c0` from 1,2-ditetradec-7-enoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15702_c0` from 1,2-Dianteisoheptadecanoyl-sn-glycerol [c0] to 1,2-di-14-methylhexadecanoylglycerol [c0]
- Changes name of `cpd15678_c0` from 1,2-dianteisoheptadecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-14-methylhexadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15422_c0` from CDP-1,2-ditetradec-7-enoylglycerol [c0] to CDP-1,2-di-(7Z)-tetradecenoylglycerol [c0]
- Changes name of `cpd15357_c0` from 2-octadec-11-enoyl-sn-glycerol 3-phosphate [c0] to 2-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15269_c0` from octadecenoate [c0] to (11Z)-Octadecenoate [c0]
- Changes name of `cpd11492_c0` from Malonyl-acyl-carrierprotein- [c0] to Malonyl-ACP [c0]
- Changes name of `cpd11486_c0` from 3-Oxohexanoyl-[acp] [c0] to 3-Oxohexanoyl-ACP [c0]
- Changes name of `cpd11522_c0` from 5-methyl-3-hydroxy-hexanoyl-ACP [c0] to (3R)-3-hydroxy-5-methylhexanoyl-ACP [c0]
- Changes name of `cpd11523_c0` from 5-methyl-trans-hex-2-enoyl-ACP [c0] to (2E)-5-methylhexenoyl-ACP [c0]
- Changes name of `cpd11421_c0` from trdrd [c0] to Reduced thioredoxin [c0]
- Changes name of `cpd11420_c0` from trdox [c0] to Oxidized thioredoxin [c0]
- Changes name of `cpd03189_c0` from 3-Carboxy-1-hydroxypropyl-ThPP [c0] to 3-Carboxy-1-hydroxypropyl-TPP [c0]
- Changes name of `cpd15239_c0` from Hexadecenoyl-ACP [c0] to (9Z)-Hexadecenoyl-ACP [c0]
- Changes name of `cpd15418_c0` from CDP-1,2-dihexadec-9-enoylglycerol [c0] to CDP-1,2-di-(9Z)-hexadecenoylglycerol [c0]
- Changes name of `cpd00239_c0` from H2S [c0] to Bisulfide (HS-) [c0]
- Changes name of `cpd00508_c0` from 3MOP [c0] to 3-methyl-2-oxopentoate [c0]
- Changes name of `cpd11490_c0` from 3-oxooctanoyl-acp [c0] to 3-Oxooctanoyl-ACP [c0]
- Changes name of `cpd11526_c0` from 7-methyl-3-hydroxy-octanoyl-ACP [c0] to (3R)-3-hydroxy-7-methyloctanoyl-ACP [c0]
- Changes name of `cpd11527_c0` from 7-methyl-trans-oct-2-enoyl-ACP [c0] to (2E)-7-methyloctenoyl-ACP [c0]
- Changes name of `cpd11469_c0` from (2E)-Dodecenoyl-[acp] [c0] to (2E)-Dodecenoyl-ACP [c0]
- Changes name of `cpd15328_c0` from 1-octadec-11-enoyl-sn-glycerol 3-phosphate [c0] to 1-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15687_c0` from CDP-1,2-dianteisopentadecanoylglycerol [c0] to CDP-1,2-di-12-methyltetradecanoylglycerol [c0]
- Changes name of `cpd11478_c0` from (R)-3-Hydroxybutanoyl-[acyl-carrier protein] [c0] to (3R)-3-Hydroxybutanoyl-ACP [c0]
- Changes name of `cpd11465_c0` from But-2-enoyl-[acyl-carrier protein] [c0] to (2E)-Butenoyl-ACP [c0]
- Changes name of `cpd15539_c0` from Phosphatidylglycerol dihexadec-9-enoyl [c0] to 1,2-di-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd00214_c0` from Palmitate [c0] to Hexadecanoate [c0]
- Changes name of `cpd11570_c0` from 3-Oxooctodecanoyl-ACP [c0] to 3-Oxooctadecanoyl-ACP [c0]
- Changes name of `cpd11571_c0` from 3-Hydroxyoctodecanoyl-ACP [c0] to (3R)-3-Hydroxyoctadecanoyl-ACP [c0]
- Changes name of `cpd15679_c0` from 1,2-diisotetradecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-12-methyltridecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15322_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol hexadec-9-enoyl [c0] to 1-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15343_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol dodecanoyl [c0] to 2-dodecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11484_c0` from HMA [c0] to (3R)-3-Hydroxytetradecanoyl-ACP [c0]
- Changes name of `cpd11467_c0` from (2E)-Tetradecenoyl-[acp] [c0] to (2E)-Tetradecenoyl-ACP [c0]
- Changes name of `cpd15704_c0` from 1,2-Diisopentadecanoyl-sn-glycerol [c0] to 1,2-di-13-methyltetradecanoylglycerol [c0]
- Changes name of `cpd15680_c0` from 1,2-diisopentadecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-13-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11489_c0` from 3-oxododecanoyl-acp [c0] to 3-Oxododecanoyl-ACP [c0]
- Changes name of `cpd11476_c0` from hexadecanoyl-acp [c0] to Hexadecanoyl-ACP [c0]
- Changes name of `cpd00134_c0` from Palmitoyl-CoA [c0] to Hexadecanoyl-CoA [c0]
- Changes name of `cpd15312_c0` from 1,2-Diacyl-sn-glycerol dioctadec-11-enoyl [c0] to 1,2-di-(11Z)-octadecenoylglycerol [c0]
- Changes name of `cpd15527_c0` from 1,2-dioctadec-11-enoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-(11Z)-octadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15420_c0` from CDP-1,2-dioctadec-11-enoylglycerol [c0] to CDP-1,2-di-(11Z)-octadecenoylglycerol [c0]
- Changes name of `cpd01080_c0` from ocdca [c0] to Octadecanoate [c0]
- Changes name of `cpd11437_c0` from fa3coa [c0] to 13-Methyltetradecanoyl-CoA [c0]
- Changes name of `cpd15674_c0` from 1-isopentadecanoyl-sn-glycerol 3-phosphate [c0] to 1-13-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11491_c0` from 3-oxotetradecanoyl-acp [c0] to 3-Oxotetradecanoyl-ACP [c0]
- Changes name of `cpd00327_c0` from strcoa [c0] to Octadecanoyl-CoA [c0]
- Changes name of `cpd15731_c0` from Diglucosyl-1,2 diisoheptadecanoylglycerol [c0] to 1,2-di-15-methylhexadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]
- Changes name of `cpd15730_c0` from Diglucosyl-1,2 distearoylglycerol [c0] to 1,2-dioctadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]
- Changes name of `cpd03847_c0` from Myristic acid [c0] to Tetradecanoate [c0]
- Changes name of `cpd11534_c0` from 11-methyl-3-hydroxy-dodecanoyl-ACP [c0] to (3R)-3-hydroxy-11-methyldodecanoyl-ACP [c0]
- Changes name of `cpd11535_c0` from 11-methyl-trans-dodec-2-enoyl-ACP [c0] to (2E)-11-methyldodecenoyl-ACP [c0]
- Changes name of `cpd02882_c0` from 4--1-D-Ribitylamino-5-aminouracil [c0] to 5-Amino-6-(1-D-ribitylamino)uracil [c0]
- Changes name of `cpd11501_c0` from 6-methyl-3-hydroxy-octanoyl-ACP [c0] to (3R)-3-hydroxy-6-methyloctanoyl-ACP [c0]
- Changes name of `cpd11502_c0` from 6-methyl-trans-oct-2-enoyl-ACP [c0] to (2E)-6-methyloctenoyl-ACP [c0]
- Changes name of `cpd00214_e0` from Palmitate [e0] to Hexadecanoate [e0]
- Changes name of `cpd11475_c0` from (2E)-Decenoyl-[acp] [c0] to (2E)-Decenoyl-ACP [c0]
- Changes name of `cpd15366_c0` from (R)-3-hydroxy-cis-dodec-5-enoyl-[acyl-carrier protein] [c0] to (3R,5Z)-3-Hydroxydodecenoyl-ACP [c0]
- Changes name of `cpd15569_c0` from trans-3-cis-5-dodecenoyl-[acyl-carrier protein] [c0] to (3E,5Z)-Dodecadienoyl-ACP [c0]
- Changes name of `cpd15684_c0` from CDP-1,2-dianteisoheptadecanoylglycerol [c0] to CDP-1,2-di-14-methylhexadecanoylglycerol [c0]
- Changes name of `cpd11481_c0` from R-3-hydroxypalmitoyl-acyl-carrierprotein- [c0] to (3R)-3-Hydroxyhexadecanoyl-ACP [c0]
- Changes name of `cpd11485_c0` from 3-oxohexadecanoyl-acp [c0] to 3-Oxohexadecanoyl-ACP [c0]
- Changes name of `cpd15323_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol octadecanoyl [c0] to 1-octadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15370_c0` from (R)-3-hydroxy-cis-vacc-11-enoyl-[acyl-carrier protein] [c0] to (3R,11Z)-3-Hydroxyoctadecenoyl-ACP [c0]
- Changes name of `cpd15568_c0` from trans-3-cis-11-vacceoyl-[acyl-carrier protein] [c0] to (3E,11Z)-Octadecadienoyl-ACP [c0]
- Changes name of `cpd15330_c0` from 1-tetradec-7-enoyl-sn-glycerol 3-phosphate [c0] to 1-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15298_c0` from tetradecenoate [c0] to (7Z)-Tetradecenoate [c0]
- Changes name of `cpd15354_c0` from 2-hexadec-9-enoyl-sn-glycerol 3-phosphate [c0] to 2-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11517_c0` from 14-methyl-3-hydroxy-hexa-decanoyl-ACP [c0] to (3R)-3-hydroxy-14-methylhexadecanoyl-ACP [c0]
- Changes name of `cpd11518_c0` from 14-methyl-trans-hexa-dec-2-enoyl-ACP [c0] to (2E)-14-methylhexadecenoyl-ACP [c0]
- Changes name of `cpd11480_c0` from D-3-Hydroxydodecanoyl-[acp] [c0] to (3R)-3-Hydroxydodecanoyl-ACP [c0]
- Changes name of `cpd15538_c0` from Phosphatidylglycerol dihexadecanoyl [c0] to 1,2-dihexadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15346_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol hexadecanoyl [c0] to 2-hexadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15733_c0` from Diglucosyl-1,2 diisotetradecanoylglycerol [c0] to 1,2-di-12-methyltridecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]
- Changes name of `cpd11542_c0` from 15-methyl-3-hydroxy-hexa-decanoyl-ACP [c0] to (3R)-3-hydroxy-15-methylhexadecanoyl-ACP [c0]
- Changes name of `cpd11543_c0` from 15-methyl-trans-hexa-dec-2-enoyl-ACP [c0] to (2E)-15-methylhexadecenoyl-ACP [c0]
- Changes name of `cpd11434_c0` from fa12coa [c0] to 14-Methylhexadecanoyl-CoA [c0]
- Changes name of `cpd15369_c0` from (R)-3-hydroxy-cis-palm-9-eoyl-[acyl-carrier protein] [c0] to (3R,9Z)-3-Hydroxyhexadecenoyl-ACP [c0]
- Changes name of `cpd15571_c0` from trans-3-cis-9-palmitoleoyl-[acyl-carrier protein] [c0] to (3E,9Z)-Hexadecadienoyl-ACP [c0]
- Changes name of `cpd15540_c0` from Phosphatidylglycerol dioctadecanoyl [c0] to 1,2-dioctadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15348_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol octadecanoyl [c0] to 2-octadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15537_c0` from Phosphatidylglycerol ditetradec-7-enoyl [c0] to 1,2-di-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15320_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol tetradec-7-enoyl [c0] to 1-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11482_c0` from (R)-3-Hydroxydecanoyl-[acyl-carrier protein] [c0] to (3R)-3-Hydroxydecanoyl-ACP [c0]
- Changes name of `cpd11487_c0` from 3-oxodecanoyl-acp [c0] to 3-Oxodecanoyl-ACP [c0]
- Changes name of `cpd15722_c0` from Diisoheptadecanoylphosphatidylglycerol [c0] to 1,2-di-15-methylhexadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15525_c0` from 1,2-dihexadec-9-enoyl-sn-glycerol 3-phosphate [c0] to 1,2-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15681_c0` from 1,2-dianteisopentadecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-12-methyltetradecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11479_c0` from D-3-Hydroxyhexanoyl-[acp] [c0] to (3R)-3-Hydroxyhexanoyl-ACP [c0]
- Changes name of `cpd15706_c0` from 1,2-Diisohexadecanoyl-sn-glycerol [c0] to 1,2-di-14-methylpentadecanoylglycerol [c0]
- Changes name of `cpd15345_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol tetradec-7-enoyl [c0] to 2-(7Z)-tetradecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15311_c0` from 1,2-Diacyl-sn-glycerol dioctadecanoyl [c0] to 1,2-dioctadecanoylglycerol [c0]
- Changes name of `cpd15344_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol tetradecanoyl [c0] to 2-tetradecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd03584_c0` from UDP-3-O-(beta-hydroxymyristoyl)-D-glucosamine [c0] to UDP-3-O-(3-hydroxytetradecanoyl)-D-glucosamine [c0]
- Changes name of `cpd00200_c0` from 4MOP [c0] to 4-Methyl-2-oxopentanoate [c0]
- Changes name of `cpd11825_c0` from Octadecenoyl-ACP [c0] to (11Z)-Octadecenoyl-ACP [c0]
- Changes name of `cpd15726_c0` from Dianteisopentadecanoylphosphatidylglycerol [c0] to 1,2-di-12-methyltetradecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11538_c0` from 13-methyl-3-hydroxy-tetra-decanoyl-ACP [c0] to (3R)-3-hydroxy-13-methyltetradecanoyl-ACP [c0]
- Changes name of `cpd11539_c0` from 13-methyl-trans-tetra-dec-2-enoyl-ACP [c0] to (2E)-13-methyltetradecenoyl-ACP [c0]
- Changes name of `cpd15701_c0` from 1,2-Diisoheptadecanoyl-sn-glycerol [c0] to 1,2-di-15-methylhexadecanoylglycerol [c0]
- Changes name of `cpd15677_c0` from 1,2-diisoheptadecanoyl-sn-glycerol 3-phosphate [c0] to 1,2-di-15-methylhexadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd11435_c0` from fa1coa [c0] to 12-Methyltridecanoyl-CoA [c0]
- Changes name of `cpd15673_c0` from 1-isotetradecanoyl-sn-glycerol 3-phosphate [c0] to 1-12-methyltridecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd00342_c0` from N-Acetylornithine [c0] to N-acetylornithine [c0]
- Changes name of `cpd15723_c0` from Dianteisoheptadecanoylphosphatidylglycerol [c0] to 1,2-di-14-methylhexadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11509_c0` from 10-methyl-3-hydroxy-dodecanoyl-ACP [c0] to (3R)-3-hydroxy-10-methyldodecanoyl-ACP [c0]
- Changes name of `cpd11510_c0` from 10-methyl-trans-dodec-2-enoyl-ACP [c0] to (2E)-10-methyldodecenoyl-ACP [c0]
- Changes name of `cpd15349_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol octadec-11-enoyl [c0] to 2-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11473_c0` from (2E)-Hexenoyl-[acp] [c0] to (2E)-Hexenoyl-ACP [c0]
- Changes name of `cpd15536_c0` from Phosphatidylglycerol ditetradecanoyl [c0] to 1,2-ditetradecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15321_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol hexadecanoyl [c0] to 1-hexadecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15676_c0` from 1-isohexadecanoyl-sn-glycerol 3-phosphate [c0] to 1-14-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd02886_c0` from UDP-3-O-(beta-hydroxymyristoyl)-N-acetylglucosamine [c0] to UDP-3-O-(3-hydroxytetradecanoyl)-N-acetylglucosamine [c0]
- Changes name of `cpd15705_c0` from 1,2-Dianteisopentadecanoyl-sn-glycerol [c0] to 1,2-di-12-methyltetradecanoylglycerol [c0]
- Changes name of `cpd15735_c0` from Diglucosyl-1,2 dianteisopentadecanoylglycerol [c0] to 1,2-di-12-methyltetradecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]
- Changes name of `cpd11530_c0` from 9-methyl-3-hydroxy-decanoyl-ACP [c0] to (3R)-3-hydroxy-9-methyldecanoyl-ACP [c0]
- Changes name of `cpd11531_c0` from 9-methyl-trans-dec-2-enoyl-ACP [c0] to (2E)-9-methyldecenoyl-ACP [c0]
- Changes name of `cpd15732_c0` from Diglucosyl-1,2 dianteisoheptadecanoylglycerol [c0] to 1,2-di-14-methylhexadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]
- Changes name of `cpd03847_e0` from Myristic acid [e0] to Tetradecanoate [c0] [e0]
- Changes name of `cpd15535_c0` from Phosphatidylglycerol didodecanoyl [c0] to 1,2-didodecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15318_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol dodecanoyl [c0] to 1-dodecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd11572_c0` from trans-Octodec-2-enoyl-ACP [c0] to (2E)-Octadecenoyl-ACP [c0]
- Changes name of `cpd15724_c0` from Diisotetradecanoylphosphatidylglycerol [c0] to 1,2-di-12-methyltridecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15683_c0` from CDP-1,2-diisoheptadecanoylglycerol [c0] to CDP-1,2-di-15-methylhexadecanoylglycerol [c0]
- Changes name of `cpd08210_c0` from ADC [c0] to 4-amino-4-deoxychorismate [c0]
- Changes name of `cpd15294_c0` from Tetradecenoyl-ACP [c0] to (7Z)-Tetradecenoyl-ACP [c0]
- Changes name of `cpd15672_c0` from 1-anteisoheptadecanoyl-sn-glycerol 3-phosphate [c0] to 1-13-methylpentadecanoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15734_c0` from Diglucosyl-1,2 diisopentadecanoylglycerol [c0] to 1,2-di-13-methyltetradecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]
- Changes name of `cpd11477_c0` from (2E)-Hexadecenoyl-[acp] [c0] to (2E)-Hexadecenoyl-ACP [c0]
- Changes name of `cpd11497_c0` from 4-methyl-3-hydroxy-hexanoyl-ACP [c0] to (3R)-3-hydroxy-4-methylhexanoyl-ACP [c0]
- Changes name of `cpd11498_c0` from 4-methyl-trans-hex-2-enoyl-ACP [c0] to (2E)-4-methylhexenoyl-ACP [c0]
- Changes name of `cpd15326_c0` from 1-hexadec-9-enoyl-sn-glycerol 3-phosphate [c0] to 1-(9Z)-hexadecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15319_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol tetradecanoyl [c0] to 1-tetradecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15362_c0` from 2-tetradec-7-enoyl-sn-glycerol 3-phosphate [c0] to 2-(7Z)-tetradecenoyl-sn-glycerol-3-phosphate [c0]
- Changes name of `cpd15306_c0` from 1,2-Diacyl-sn-glycerol didodecanoyl [c0] to 1,2-didodecanoylglycerol [c0]
- Changes name of `cpd00461_c0` from Oxopent-4-enoate [c0] to 2-Hydroxy-2,4-pentadienoate [c0]
- Changes name of `cpd15729_c0` from Diglucosyl-1,2 dimyristoylglycerol [c0] to 1,2-ditetradecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]
- Changes name of `cpd15368_c0` from (R)-3-hydroxy-cis-myristol-7-eoyl-[acyl-carrier protein] [c0] to (3R,7Z)-3-Hydroxytetradecenoyl-ACP [c0]
- Changes name of `cpd15570_c0` from trans-3-cis-7-myristoleoyl-[acyl-carrier protein] [c0] to (3E,7Z)-Tetradecadienoyl-ACP [c0]
- Changes name of `cpd15728_c0` from Diglucosyl-1,2 dipalmitoylglycerol [c0] to 1,2-dihexadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]
- Changes name of `cpd15541_c0` from Phosphatidylglycerol dioctadec-11-enoyl [c0] to 1,2-di-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15725_c0` from Diisopentadecanoylphosphatidylglycerol [c0] to 1,2-di-13-methyltetradecanoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15324_c0` from 1-Acyl-sn-glycero-3-phosphoglycerol octadec-11-enoyl [c0] to 1-(11Z)-octadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15703_c0` from 1,2-Diisotetradecanoyl-sn-glycerol [c0] to 1,2-di-12-methyltridecanoylglycerol [c0]
- Changes name of `cpd15347_c0` from 2-Acyl-sn-glycero-3-phosphoglycerol hexadec-9-enoyl [c0] to 2-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]
- Changes name of `cpd15307_c0` from 1,2-Diacyl-sn-glycerol ditetradecanoyl [c0] to 1,2-ditetradecanoylglycerol [c0]
- Changes name of `cpd15310_c0` from 1,2-Diacyl-sn-glycerol dihexadec-9-enoyl [c0] to 1,2-di-(9Z)-hexadecenoylglycerol [c0]
- Changes name of `cpd21088_c0` from Pimelyl-[acyl-carrier protein] methyl ester [c0] to Pimeloyl-ACP methyl ester [c0]
- Changes name of `cpd21087_c0` from Pimelyl-[acyl-carrier protein] [c0] to Pimeloyl-ACP [c0]
- Changes name of `cpd12489_c0` from cis-3-Decenoyl-[acyl-carrier protein] [c0] to (3Z)-Decenoyl-ACP [c0]
- Changes name of `cpd36635_c0` from Malonyl-acp-methyl-ester [c0] to Malonyl-ACP-methyl-ester [c0]
- Changes name of `cpd22028_c0` from 3-Ketopimeloyl-ACP-methyl-esters [c0] to 3-Ketopimeloyl-ACP-methyl-ester [c0]
- Changes name of `cpd22065_c0` from 3-hydroxypimeloyl-ACP-methyl-esters [c0] to (3R)-3-Hydroxypimeloyl-ACP-methyl-ester [c0]
- Changes name of `cpd27021_c0` from Enoylpimeloyl-ACP-methyl-esters [c0] to (2E)-Enoylpimeloyl-ACP-methyl-ester [c0]
- Changes name of `cpd27020_c0` from Enoylglutaryl-ACP-methyl-esters [c0] to (2E)-Enoylglutaryl-ACP-methyl-ester [c0]
- Changes name of `cpd27180_c0` from Glutaryl-ACP-methyl-esters [c0] to Glutaryl-ACP-methyl-ester [c0]
- Changes name of `cpd00239_e0` from H2S [e0] to Bisulfide (HS-) [e0]

These are all of the metabolites whose names I changed in [the MIT1002 model](https://github.com/C-CoMP-STC/GEM-mit1002) that also appear in this model.