### PR TITLE
Fix: explain xml supremacy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+#### Main improvements in this PR:
+<!-- Try to be as clear as possible in providing a summary of the work and reference the corresponding issue.
+Is it fixing/adding something in the model?
+Is it an additional test/function/dataset? 
+e.g. This PR improves/fixes # by ...
+-->
+
+
+**I hereby confirm that I have:**
+<!-- *Note: replace [ ] with [X] to check the box. -->
+- [ ] Made my edits to the model on the XML file
+- [ ] Tested my code on my own computer for running the model
+- [ ] Selected `develop` as a target branch
+- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ Upon manual trigger:
 ## To contribute to the model
 1. Make a GitHub account
 2. Make a fork/branch of this repo
-3. Make your edits
+3. Make your edits to the model on the XML file\
 4. Open a pull request


### PR DESCRIPTION
This PR adds documentation to the README and a checkbox to the PR template that reminds contributors to curate the XML file of the model.