### PR TITLE
Fix: copy more changes made to the MIT1002 model

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -12650,25 +12650,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00413_c0" sboTerm="SBO:0000247" id="M_cpd00413_c0" name="Glutaryl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C26H38N7O19P3S">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00413_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00413"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C26H42N7O19P3S/c1-26(2,21(39)24(40)29-7-6-15(34)28-8-9-56-17(37)5-3-4-16(35)36)11-49-55(46,47)52-54(44,45)48-10-14-20(51-53(41,42)43)19(38)25(50-14)33-13-32-18-22(27)30-12-31-23(18)33/h12-14,19-21,25,38-39H,3-11H2,1-2H3,(H,28,34)(H,29,40)(H,35,36)(H,44,45)(H,46,47)(H2,27,30,31)(H2,41,42,43)/p-5/t14-,19-,20-,21+,25-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/SYKWLIJQEHRDNH-CKRMAKSASA-I"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/glutcoa"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00527"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM382"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTARYL-COA"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00650_c0" sboTerm="SBO:0000247" id="M_cpd00650_c0" name="Crotonyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C25H36N7O17P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -21887,13 +21868,13 @@
           <speciesReference species="M_cpd11441_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00646_c0" sboTerm="SBO:0000176" id="R_rxn00646_c0" name="L-glutamate:L-cysteine gamma-ligase (ADP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -22237,12 +22218,18 @@
           <speciesReference species="M_cpd03114_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08675"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05457_c0" sboTerm="SBO:0000176" id="R_rxn05457_c0" name="[Acyl-carrier-protein] acetyltransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -22908,14 +22895,7 @@
           <speciesReference species="M_cpd00477_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19265"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06330"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04350"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11920"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11725"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14820"/>
-          </fbc:and>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01795"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01218_c0" sboTerm="SBO:0000176" id="R_rxn01218_c0" name="2&apos;-Deoxycytidine 5&apos;-monophosphate phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -25147,12 +25127,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
             <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
             </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -25879,16 +25863,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
-            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02860"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09255"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07620"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -27029,19 +27013,15 @@
         <fbc:geneProductAssociation>
           <fbc:or>
             <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11845"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05890"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
             </fbc:and>
             <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08675"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
             </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08675"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -27582,15 +27562,18 @@
           <speciesReference species="M_cpd02060_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02860"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09255"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07620"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00913_c0" sboTerm="SBO:0000176" id="R_rxn00913_c0" name="Guanosine 5&apos;-monophosphate phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -28526,13 +28509,13 @@
           <speciesReference species="M_cpd11439_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00612_c0" sboTerm="SBO:0000176" id="R_rxn00612_c0" name="sn-Glycerol-3-phosphate:NADP+ 2-oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -29191,16 +29174,7 @@
           <speciesReference species="M_cpd15561_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15560"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
-            </fbc:and>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15560"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
-            </fbc:and>
-          </fbc:or>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02798_c0" sboTerm="SBO:0000176" id="R_rxn02798_c0" name="Estrone 3-sulfate sulfohydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -29852,14 +29826,22 @@
           <speciesReference species="M_cpd03129_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11845"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05890"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09260"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07610"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn11946_c0" sboTerm="SBO:0000176" id="R_rxn11946_c0" name="R05614 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -30120,14 +30102,22 @@
           <speciesReference species="M_cpd02060_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11845"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05890"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09260"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07610"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01280_c0" sboTerm="SBO:0000176" id="R_rxn01280_c0" name="(R)-Glycerate:NAD+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -30701,29 +30691,12 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03630"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03010"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03635"/>
-            </fbc:and>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09660"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05060"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02815"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12990"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17360"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13535"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17960"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16515"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06280"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08380"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04260"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06395"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00570"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17565"/>
-            </fbc:and>
-          </fbc:or>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03630"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03010"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03635"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03625"/>
+          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01872_c0" sboTerm="SBO:0000176" id="R_rxn01872_c0" name="succinyl-CoA:enzyme N6-(dihydrolipoyl)lysine S-succinyltransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -30913,47 +30886,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17205"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16215"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn00499_c0" sboTerm="SBO:0000176" id="R_rxn00499_c0" name="(S)-Lactate:NAD+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00499_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00499"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LDH_L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00703"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/23447"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101040"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:L-LACTATE-DEHYDROGENASE-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.27"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00016"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00159_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00020_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15560"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
-            </fbc:and>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15560"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
-            </fbc:and>
-          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08844_c0" sboTerm="SBO:0000176" id="R_rxn08844_c0" name="Lysophospholipase L2 (2-acylglycerophosphoethanolamine, n-C18:1) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -31533,12 +31465,18 @@
           <speciesReference species="M_cpd12689_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08675"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03869_c0" sboTerm="SBO:0000176" id="R_rxn03869_c0" name="Acylamide aminohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -32074,14 +32012,22 @@
           <speciesReference species="M_cpd03126_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11845"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05890"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09260"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07610"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn09562_c0" sboTerm="SBO:0000176" id="R_rxn09562_c0" name="Guanylate kinase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -36240,13 +36186,13 @@
           <speciesReference species="M_cpd11434_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00214_c0" sboTerm="SBO:0000176" id="R_rxn00214_c0" name="UDP-glucose 4-epimerase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -36776,16 +36722,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
-            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02860"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09255"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07620"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -37590,20 +37536,10 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16405"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11410"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01760"/>
-            </fbc:and>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16405"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11410"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01760"/>
-            </fbc:and>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09285"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15635"/>
-            </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01760"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11410"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16405"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09285"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -38222,48 +38158,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00945"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn01802_c0" sboTerm="SBO:0000176" id="R_rxn01802_c0" name="Glutaryl-CoA:(acceptor) 2,3-oxidoreductase (decarboxylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01802_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01802"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLTCOAD"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUTCOADHc"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02487"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/13392"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/30850"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100293"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.99.7"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00252"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00015_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00413_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00650_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00982_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02317_c0" sboTerm="SBO:0000176" id="R_rxn02317_c0" name="ITP:D-Tagatose 6-phosphate 1-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -39032,10 +38926,7 @@
           <speciesReference species="M_cpd00110_c0" stoichiometry="2" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15560"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
-          </fbc:and>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15560"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08126_c0" sboTerm="SBO:0000176" id="R_rxn08126_c0" name="Amylomaltase (maltotriose) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -39567,16 +39458,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02860"/>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
-            </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09255"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07620"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -39919,13 +39810,13 @@
           <speciesReference species="M_cpd15238_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08380_c0" sboTerm="SBO:0000176" id="R_rxn08380_c0" name="RXN0-382.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -40202,11 +40093,9 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11245"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13010"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14325"/>
-            </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11245"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13010"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14325"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16905"/>
           </fbc:or>
         </fbc:geneProductAssociation>
@@ -40586,12 +40475,18 @@
           <speciesReference species="M_cpd03119_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08675"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn04139_c0" sboTerm="SBO:0000176" id="R_rxn04139_c0" name="2-Octaprenyl-3-methyl-6-methoxy-1,4-benzoquinone ,NADPH2:oxygen oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -40822,14 +40717,22 @@
           <speciesReference species="M_cpd03572_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11845"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05890"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09260"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07610"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00735_c0" sboTerm="SBO:0000176" id="R_rxn00735_c0" name="(2R,3S)-3-methylmalate:NAD+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -40942,12 +40845,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
             <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
             </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -41466,14 +41373,22 @@
           <speciesReference species="M_cpd02125_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11845"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05890"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09260"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07610"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08089_c0" sboTerm="SBO:0000176" id="R_rxn08089_c0" name="1-octadec-7-enoyl-sn-glycerol 3-phosphate O-acyltransferase (n-C18:1) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -41546,11 +41461,17 @@
           <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06650"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06655"/>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14775"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14770"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06655"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06650"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13005"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn10269_c0" sboTerm="SBO:0000176" id="R_rxn10269_c0" name="anteisopentadecanoyl-Phosphatidylglycerophosphate phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -42048,12 +41969,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
             <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
             </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -42451,16 +42376,7 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08735"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14775"/>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15145"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09960"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14770"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07555"/>
-            </fbc:and>
-          </fbc:or>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08735"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00379_c0" sboTerm="SBO:0000176" id="R_rxn00379_c0" name="ATP:sulfate adenylyltransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -43180,16 +43096,7 @@
           <speciesReference species="M_cpd15499_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15560"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
-            </fbc:and>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15560"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
-            </fbc:and>
-          </fbc:or>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00947_c0" sboTerm="SBO:0000176" id="R_rxn00947_c0" name="Palmitate:CoA ligase (AMP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -43231,13 +43138,13 @@
           <speciesReference species="M_cpd00134_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03247_c0" sboTerm="SBO:0000176" id="R_rxn03247_c0" name="(S)-Hydroxyoctanoyl-CoA hydro-lyase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -43274,14 +43181,22 @@
           <speciesReference species="M_cpd03130_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11845"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05890"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09260"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07610"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn10210_c0" sboTerm="SBO:0000176" id="R_rxn10210_c0" name="isohexadecanoyl-glycerol-3-phosphate O-acyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -43592,13 +43507,13 @@
           <speciesReference species="M_cpd00279_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00410_c0" sboTerm="SBO:0000176" id="R_rxn00410_c0" name="UTP:ammonia ligase (ADP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -44761,12 +44676,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
             <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
             </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -46290,16 +46209,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
-            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02860"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09255"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07620"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -46438,13 +46357,13 @@
           <speciesReference species="M_cpd11435_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03136_c0" sboTerm="SBO:0000176" id="R_rxn03136_c0" name="1-(5&apos;-Phosphoribosyl)-5-amino-4-(N-succinocarboxamide)-imidazole AMP-lyase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -48020,12 +47939,18 @@
           <speciesReference species="M_cpd03123_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08675"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn04113_c0" sboTerm="SBO:0000176" id="R_rxn04113_c0" name="isopentenyl-diphosphate:NAD(P)+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -48942,11 +48867,12 @@
           <speciesReference species="M_cpd00157_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11245"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13010"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14325"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16905"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn10202_c0" sboTerm="SBO:0000176" id="R_rxn10202_c0" name="glycerol-3-phosphate: acyl-coa acyltransferase (16:0) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -49071,13 +48997,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
             <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
             </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -49289,13 +49218,13 @@
           <speciesReference species="M_cpd11432_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn12642_c0" sboTerm="SBO:0000176" id="R_rxn12642_c0" name="RXN0-6978.c [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -50323,13 +50252,13 @@
           <speciesReference species="M_cpd00327_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05323_c0" sboTerm="SBO:0000176" id="R_rxn05323_c0" name="Tetradecanoyl-[acyl-carrier protein]:malonyl-CoA C-acyltransferase(decarboxylating, oxoacyl- and enoyl-reducing) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -50714,13 +50643,13 @@
           <speciesReference species="M_cpd11437_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02056_c0" sboTerm="SBO:0000176" id="R_rxn02056_c0" name="S-Adenosyl-L-methionine:uroporphyrin-III C-methyltransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -51019,12 +50948,18 @@
           <speciesReference species="M_cpd03117_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08675"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01924_c0" sboTerm="SBO:0000176" id="R_rxn01924_c0" name="isobutyryl-CoA dehydrogenase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -52549,14 +52484,22 @@
           <speciesReference species="M_cpd03127_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11845"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05890"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09260"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07610"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01521_c0" sboTerm="SBO:0000176" id="R_rxn01521_c0" name="2&apos;-Deoxyuridine 5&apos;-monophosphate phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -52948,11 +52891,8 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15145"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14770"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14775"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07555"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09960"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14770"/>
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
@@ -54132,16 +54072,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
-            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02860"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09255"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07620"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -54399,17 +54339,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02860"/>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
-            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10275"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08010"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02860"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13270"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10725"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00425"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10530"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09255"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13445"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07620"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -54514,11 +54453,12 @@
           <speciesReference species="M_cpd00646_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11245"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13010"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14325"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16905"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00342_c0" sboTerm="SBO:0000176" id="R_rxn00342_c0" name="L-Asparagine amidohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -54876,14 +54816,22 @@
           <speciesReference species="M_cpd00650_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11845"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05890"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09260"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07610"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01858_c0" sboTerm="SBO:0000176" id="R_rxn01858_c0" name="Deoxyadenosine aminohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -55477,14 +55425,22 @@
           <speciesReference species="M_cpd03125_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11845"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05890"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-          </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10455"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09260"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07610"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13375"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02465_c0" sboTerm="SBO:0000176" id="R_rxn02465_c0" name="N-acetyl-L-glutamate-5-semialdehyde:NADP+ 5-oxidoreductase (phosphrylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -56784,12 +56740,16 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
             <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
               <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
             </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07630"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
@@ -56996,12 +56956,18 @@
           <speciesReference species="M_cpd03121_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02305"/>
+            </fbc:and>
+            <fbc:and>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05765"/>
+            </fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08000"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08675"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02144_c0" sboTerm="SBO:0000176" id="R_rxn02144_c0" name="4-carboxymethylbut-3-en-4-olide enol-lactonohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -57391,13 +57357,13 @@
           <speciesReference species="M_cpd15274_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00525_c0" sboTerm="SBO:0000176" id="R_rxn00525_c0" name="L-arogenate:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -58214,13 +58180,13 @@
           <speciesReference species="M_cpd01695_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:and>
+          <fbc:or>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10945"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11950"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03070"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15710"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09360"/>
-          </fbc:and>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03445_c0" sboTerm="SBO:0000176" id="R_rxn03445_c0" name="O-Phospho-4-hydroxy-L-threonine:2-oxoglutarate aminotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -59275,8 +59241,10 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09835"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09825"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09850"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02575"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02845"/>
+            <fbc:or>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02575"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02845"/>
+            </fbc:or>
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
@@ -59311,6 +59279,7 @@
           <fbc:and>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06275"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14805"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06280"/>
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
@@ -61857,6 +61826,13 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd10516_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00560"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00565"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00570"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01208_c0" sboTerm="SBO:0000176" id="R_rxn01208_c0" name="R01652 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -63367,6 +63343,13 @@
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00209_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02805"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02810"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02815"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00979_c0" sboTerm="SBO:0000176" id="R_rxn00979_c0" name="glycolaldehyde:NAD+ oxidoreductase" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
@@ -63977,6 +63960,46 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17020"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn08762_c0" sboTerm="SBO:0000185" id="R_rxn08762_c0" name="K+ importing ATPase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn08762_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08762"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/7.2.2.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/Kabc"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/Kabcpp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.6.3.10-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.6.3.12-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN-2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100657"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00205_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00008_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00205_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05080"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05075"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05070"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05065"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05060"/>
+          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
     </listOfReactions>
@@ -64749,84 +64772,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949944.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19265" fbc:name="MASE_RS19265" fbc:label="G_MASE_RS19265">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS19265">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951376.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06330" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06330" fbc:name="MASE_RS06330" fbc:label="G_MASE_RS06330">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS06330">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948922.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04350" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04350" fbc:name="MASE_RS04350" fbc:label="G_MASE_RS04350">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS04350">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948543.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11920" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11920" fbc:name="MASE_RS11920" fbc:label="G_MASE_RS11920">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS11920">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949999.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11725" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11725" fbc:name="MASE_RS11725" fbc:label="G_MASE_RS11725">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS11725">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949960.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14820" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14820" fbc:name="MASE_RS14820" fbc:label="G_MASE_RS14820">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS14820">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950553.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -67472,19 +67417,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS13535" sboTerm="SBO:0000243" fbc:id="G_MASE_RS13535" fbc:name="MASE_RS13535" fbc:label="G_MASE_RS13535">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS13535">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950308.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS14890" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14890" fbc:name="MASE_RS14890" fbc:label="G_MASE_RS14890">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -67810,19 +67742,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09660" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09660" fbc:name="MASE_RS09660" fbc:label="G_MASE_RS09660">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS09660">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949556.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS05060" sboTerm="SBO:0000243" fbc:id="G_MASE_RS05060" fbc:name="MASE_RS05060" fbc:label="G_MASE_RS05060">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -67849,58 +67768,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12990" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12990" fbc:name="MASE_RS12990" fbc:label="G_MASE_RS12990">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS12990">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950201.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17360" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17360" fbc:name="MASE_RS17360" fbc:label="G_MASE_RS17360">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS17360">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951007.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17960" fbc:name="MASE_RS17960" fbc:label="G_MASE_RS17960">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS17960">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951122.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16515" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16515" fbc:name="MASE_RS16515" fbc:label="G_MASE_RS16515">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS16515">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950852.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS06280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06280" fbc:name="MASE_RS06280" fbc:label="G_MASE_RS06280">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -67914,45 +67781,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08380" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08380" fbc:name="MASE_RS08380" fbc:label="G_MASE_RS08380">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS08380">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949304.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS04260" sboTerm="SBO:0000243" fbc:id="G_MASE_RS04260" fbc:name="MASE_RS04260" fbc:label="G_MASE_RS04260">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS04260">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948525.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS06395" sboTerm="SBO:0000243" fbc:id="G_MASE_RS06395" fbc:name="MASE_RS06395" fbc:label="G_MASE_RS06395">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS06395">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948931.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS00570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00570" fbc:name="MASE_RS00570" fbc:label="G_MASE_RS00570">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -67960,19 +67788,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947814.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS17565" sboTerm="SBO:0000243" fbc:id="G_MASE_RS17565" fbc:name="MASE_RS17565" fbc:label="G_MASE_RS17565">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS17565">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951046.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -71476,32 +71291,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15145" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15145" fbc:name="MASE_RS15145" fbc:label="G_MASE_RS15145">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS15145">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950616.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS09960" sboTerm="SBO:0000243" fbc:id="G_MASE_RS09960" fbc:name="MASE_RS09960" fbc:label="G_MASE_RS09960">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS09960">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693498.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS14770" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14770" fbc:name="MASE_RS14770" fbc:label="G_MASE_RS14770">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -71509,19 +71298,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950543.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07555" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07555" fbc:name="MASE_RS07555" fbc:label="G_MASE_RS07555">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS07555">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949147.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -75918,6 +75694,16 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
+      <fbc:geneProduct fbc:id="G_MASE_RS13375" fbc:name="G_MASE_RS13375" fbc:label="G_MASE_RS13375"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS05080" fbc:name="sapA" fbc:label="G_MASE_RS05080"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS05075" fbc:name="sapB" fbc:label="G_MASE_RS05075"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS05070" fbc:name="sapC" fbc:label="G_MASE_RS05070"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS05065" fbc:name="sapD" fbc:label="G_MASE_RS05065"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS03625" fbc:name="G_MASE_RS03625" fbc:label="G_MASE_RS03625"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS02805" fbc:name="nrtA" fbc:label="G_MASE_RS02805"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS02810" fbc:name="nrtB" fbc:label="G_MASE_RS02810"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS00560" fbc:name="sfuA" fbc:label="G_MASE_RS00560"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS00565" fbc:name="sfuB" fbc:label="G_MASE_RS00565"/>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>


### PR DESCRIPTION
This pull request:

- Adds new gene `MASE_RS13375` (enoyl-CoA hydratase) to the model (see [MIT1002 PR #252](https://github.com/C-CoMP-STC/GEM-mit1002/pull/252))
- Changes the GPRs of `rxn01451_c0`, `rxn03249_c0`, `rxn03246_c0`, `rxn03244_c0`, `rxn03242_c0`, `rxn06777_c0`, and `rxn03239_c0` to `(MASE_RS02310 and MASE_RS02305) or (MASE_RS05770 and MASE_RS05765) or MASE_RS08000 or MASE_RS08675` (see [MIT1002 PR #236](https://github.com/C-CoMP-STC/GEM-mit1002/pull/236))
- Changes the GPRs of `rxn02167_c0`, `rxn03250_c0`, `rxn03247_c0`, `rxn03245_c0`, `rxn02911_c0`, `rxn03241_c0`, `rxn03240_c0`, `rxn02949_c0`, and `rxn02934_c0` to `(MASE_RS02310 and MASE_RS02305) or (MASE_RS05770 and MASE_RS05765) or MASE_RS11845 or MASE_RS05890 or MASE_RS10455 or MASE_RS09260 or MASE_RS07610 or MASE_RS13375` (see [MIT1002 PR #236](https://github.com/C-CoMP-STC/GEM-mit1002/pull/236))
- Changes the GPRs of `rxn00872_c0`, `rxn03251_c0`, `rxn02679_c0`, `rxn03253_c0`, `rxn02720_c0`, `rxn02803_c0`, and `rxn00946_c0` to `MASE_RS10275 or MASE_RS08010 or MASE_RS02860 or MASE_RS13270 or MASE_RS10725 or MASE_RS00425 or MASE_RS10530 or MASE_RS09255 or MASE_RS13445 or MASE_RS07620` (see [MIT1002 PR #236](https://github.com/C-CoMP-STC/GEM-mit1002/pull/236))
- Changes the GPRs of `rxn00874_c0`, `rxn03248_c0`, `rxn02680_c0`, `rxn03243_c0`, `rxn06510_c0`, and `rxn02804_c0` to `(MASE_RS02310 and MASE_RS02305) or (MASE_RS05770 and MASE_RS05765) or MASE_RS08005 or MASE_RS07630` (see [MIT1002 PR #236](https://github.com/C-CoMP-STC/GEM-mit1002/pull/236))
- Removes `rxn01802_c0` and `cpd00413_c0` from the model (see [MIT1002 PR #237](https://github.com/C-CoMP-STC/GEM-mit1002/pull/237))
- Changes the GPRs of `rxn00947_c0`, `rxn00988_c0`, `rxn05247_c0`, `rxn05248_c0`, `rxn05249_c0`, `rxn05250_c0`, `rxn05251_c0`, `rxn05252_c0`, `rxn05736_c0`, `rxn09448_c0`, `rxn09449_c0`, and `rxn09450_c0` to `MASE_RS10945 or MASE_RS11950 or MASE_RS03070 or MASE_RS15710 or MASE_RS09360` (see [MIT1002 PR #238](https://github.com/C-CoMP-STC/GEM-mit1002/pull/238))
- Changes the GPR of `rxn05145_c0` to `MASE_RS03630 and MASE_RS03010 and MASE_RS03635 and MASE_RS03625` (see [MIT1002 PR #239](https://github.com/C-CoMP-STC/GEM-mit1002/pull/239))
- Changes the GPR of `rxn08070_c0` to `MASE_RS06275 and MASE_RS14805 and MASE_RS06280` (see [MIT1002 PR #239](https://github.com/C-CoMP-STC/GEM-mit1002/pull/239))
- Adds new genes `MASE_RS02805` (nrtA), `MASE_RS02810` (nrtB), `MASE_RS00560` (sfuA), `MASE_RS00565` (sfuB), `MASE_RS05080` (sapA), `MASE_RS05075` (sapB), `MASE_RS05070` (sapC), and `MASE_RS05065` (sapD) to the model (see [MIT1002 PR #239](https://github.com/C-CoMP-STC/GEM-mit1002/pull/239))
- Sets the previously-empty GPR of `rxn05171_c0` to `MASE_RS02805 and MASE_RS02810 and MASE_RS02815` (see [MIT1002 PR #239](https://github.com/C-CoMP-STC/GEM-mit1002/pull/239))
- Sets the previously-empty GPR of `rxn05195_c0` to `MASE_RS00560 and MASE_RS00565 and MASE_RS00570` (see [MIT1002 PR #239](https://github.com/C-CoMP-STC/GEM-mit1002/pull/239))
- Adds new reaction `rxn08762_c0`: K<sup>+</sup> [e0] + ATP [c0] + H<sub>2</sub>O [c0] + ATP [c0] => K<sup>+</sup> [c0] + ADP [c0] + Phosphate [c0] + H<sup>+</sup> [c0], GPR: `MASE_RS05080 and MASE_RS05075 and MASE_RS05070 and MASE_RS05065 and MASE_RS05060` (see [MIT1002 PR #239](https://github.com/C-CoMP-STC/GEM-mit1002/pull/239))
- Removes `MASE_RS09660`, `MASE_RS12990`, `MASE_RS17360`, `MASE_RS13535`, `MASE_RS17960`, `MASE_RS16515`, `MASE_RS08380`, `MASE_RS04260`, `MASE_RS06395`, and `MASE_RS17565` from the model (see [MIT1002 PR #239](https://github.com/C-CoMP-STC/GEM-mit1002/pull/239))
- Changes the GPR of `rxn00006_c0` to `MASE_RS01760 or MASE_RS11410 or MASE_RS16405 or MASE_RS09285` (see [MIT1002 PR #240](https://github.com/C-CoMP-STC/GEM-mit1002/pull/240))
- Changes the GPRs of `rxn14425_c0` and `rxn14426_c0` to `MASE_RS09830 and MASE_RS09820 and MASE_RS09835 and MASE_RS09825 and MASE_RS09850 and (MASE_RS02575 or MASE_RS02845)` (see [MIT1002 PR #241](https://github.com/C-CoMP-STC/GEM-mit1002/pull/241))
- Changes the GPR of `rxn00145_c0` to `MASE_RS15560` (see [MIT1002 PR #245](https://github.com/C-CoMP-STC/GEM-mit1002/pull/245))
- Changes the GPRs of `rxn08792_c0` and `rxn08793_c0` to `MASE_RS17475` (see [MIT1002 PR #245](https://github.com/C-CoMP-STC/GEM-mit1002/pull/245))
- Removes `rxn00499_c0` from the model (see [MIT1002 PR #245](https://github.com/C-CoMP-STC/GEM-mit1002/pull/245))
- Changes the GPR of `rxn00192_c0` to `MASE_RS01795` (see [MIT1002 PR #246](https://github.com/C-CoMP-STC/GEM-mit1002/pull/246))
- Removes `MASE_RS19265`, `MASE_RS06330`, `MASE_RS04350`, `MASE_RS11920`, `MASE_RS11725`, and `MASE_RS14820` from the model (see [MIT1002 PR #246](https://github.com/C-CoMP-STC/GEM-mit1002/pull/246))
- Changes the GPR of `rxn00085_c0` to `MASE_RS14775 and MASE_RS14770` (see [MIT1002 PR #248](https://github.com/C-CoMP-STC/GEM-mit1002/pull/248))
- Changes the GPR of `rxn00184_c0` to `MASE_RS08735` (see [MIT1002 PR #248](https://github.com/C-CoMP-STC/GEM-mit1002/pull/248))
- Changes the GPR of `rxn00189_c0` to `(MASE_RS14775 and MASE_RS14770) or (MASE_RS06655 and MASE_RS06650) or MASE_RS13005` (see [MIT1002 PR #248](https://github.com/C-CoMP-STC/GEM-mit1002/pull/248))
- Removes `MASE_RS07555`, `MASE_RS15145`, and `MASE_RS09960` from the model (see [MIT1002 PR #248](https://github.com/C-CoMP-STC/GEM-mit1002/pull/248))
- Changes the GPRs of `rxn00743_c0`, `rxn02166_c0`, and `rxn03167_c0` to `MASE_RS11245 or MASE_RS13010 or MASE_RS14325 or MASE_RS16905` (see [MIT1002 PR #249](https://github.com/C-CoMP-STC/GEM-mit1002/pull/249))

All of the genes in the new GPRs were reciprocal best BLAST hits of the genes mentioned in the indicated PRs from the MIT1002 repository. In most cases, RefSeq and/or eggNOG also annotated them with the same function(s) as their reciprocal best hits in the MIT1002 genome. If the reciprocal best hit of an MIT1002 gene was a pseudogene in the ATCC27126 genome, I left it out of the GPR. I also found some genes in the ATCC27126 genome that were annotated with the same functions as genes in the MIT1002 genome that weren’t reciprocal best hits and added those to these GPRs as appropriate. Some of the genes that I removed weren’t reciprocal best hits of any genes in the MIT1002 genome (I only noticed them because they were already in the GPRs of reactions that I’d edited in the MIT1002 model), but only had vague and/or non-metabolic annotations from RefSeq and eggNOG (e.g. `MASE_RS15145`, which was just annotated as “redoxin”).