### PR TITLE
Feat: add new prolyl 4-hydroxylase isozyme

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -49441,7 +49441,10 @@
           <speciesReference species="M_cpd00851_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03015"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03015"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05160"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01332_c0" sboTerm="SBO:0000176" id="R_rxn01332_c0" name="Phosphoenolpyruvate:D-erythrose-4-phosphate C-(1-carboxyvinyl)transferase (phosphate hydrolysing, 2-carboxy-2-oxoethyl-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -78667,6 +78670,7 @@
       <fbc:geneProduct fbc:id="G_MASE_RS02865" fbc:name="G_MASE_RS02865" fbc:label="G_MASE_RS02865"/>
       <fbc:geneProduct fbc:id="G_MASE_RS14730" fbc:name="acnD" fbc:label="G_MASE_RS14730"/>
       <fbc:geneProduct fbc:id="G_MASE_RS14735" fbc:name="prpF" fbc:label="G_MASE_RS14735"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS05160" fbc:name="G_MASE_RS05160" fbc:label="G_MASE_RS05160"/>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new gene `MASE_RS05160`: proline 4-hydroxylase
- Changes the GPR of `rxn00932_c0` from `MASE_RS03015` to `MASE_RS03015 or MASE_RS05160`

**I hereby confirm that I have:**
<!-- *Note: replace [ ] with [X] to check the box. -->
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists