### PR TITLE
Fix: remove unsupported lysine uptake pathway

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -18693,25 +18693,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00039_e0" sboTerm="SBO:0000247" id="M_cpd00039_e0" name="L-Lysine [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C6H15N2O2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00039_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00039"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C6H14N2O2/c7-4-2-1-3-5(8)6(9)10/h5H,1-4,7-8H2,(H,9,10)/p+1/t5-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/KDXKERNSBIXSRK-YFKPBYRVSA-O"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/lys__L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00047"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM78"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LYS"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd15307_c0" sboTerm="SBO:0000247" id="M_cpd15307_c0" name="1,2-ditetradecanoylglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C31H60O5">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -57531,35 +57512,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12240"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn05305_c0" sboTerm="SBO:0000655" id="R_rxn05305_c0" name="L-lysine transport out via proton antiport reversible [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05305_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05305"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LYSt6"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LYSt3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LYSt3pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LYSt3r"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101267"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00039_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00039_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10910"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn09014_c0" sboTerm="SBO:0000176" id="R_rxn09014_c0" name="RXN0-5107.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -62645,11 +62597,6 @@
       <reaction metaid="meta_R_EX_cpd00305_e0" sboTerm="SBO:0000627" id="R_EX_cpd00305_e0" name="Exchange for Thiamin [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd00305_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
-      <reaction metaid="meta_R_EX_cpd00039_e0" sboTerm="SBO:0000627" id="R_EX_cpd00039_e0" name="Exchange for L-Lysine [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd00039_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
       <reaction metaid="meta_R_EX_cpd00246_e0" sboTerm="SBO:0000627" id="R_EX_cpd00246_e0" name="Exchange for Inosine [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes `rxn05305_c0` (lysine:proton symport)
- Removes `EX_cpd00039_e0` (lysine exchange)
- Removes `cpd00039_e0` (extracellular lysine)

`MASE_RS10910` was not annotated with any specific functions and no other genes were definitively annotated as lysine transporters. We have experimental data showing that MIT1002 can grow on media with lysine as the only carbon source, which is why that model has a lysine transport reaction with no GPR, but we do not have any such data for ATCC27126.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists