### PR TITLE
Fix: add annotations for rxn08239_c0

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -66958,7 +66958,20 @@
           <speciesReference species="M_cpd00149_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction id="R_rxn08239_c0" name="Cobalt (Co+2) ABC transporter" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_rxn08239_c0" sboTerm="SBO:0000176" id="R_rxn08239_c0" name="Cobalt (Co+2) ABC transporter" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn08239_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/COBALT2abcpp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96819"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08239"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
         <listOfReactants>
           <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>


### PR DESCRIPTION
#### Main improvements in this PR:

This PR adds annotations to `rxn08239_c0`, which I forgot to do in #23.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists