### PR TITLE
Fix: Add isolated gene MASE_RS15635 to catalase GPR

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -37668,6 +37668,7 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11410"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16405"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09285"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15635"/>
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request changes the GPR of `rxn00006_c0` from `MASE_RS01760 or MASE_RS11410 or MASE_RS16405 or MASE_RS09285` to `MASE_RS01760 or MASE_RS11410 or MASE_RS16405 or MASE_RS09285 or MASE_RS15635`.

I noticed that `MASE_RS15635` wasn’t in the GPR of any reaction, and while I’m not sure when that happened, it is clearly annotated as a catalase, so I’m adding it to the GPR of `rxn00006_c0`.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists