### PR TITLE
Feat: add and remove reactions recently added to or removed from MIT1002 model

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -1034,34 +1034,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15736_c0" sboTerm="SBO:0000247" id="M_cpd15736_c0" name="1,2-di-14-methylpentadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C47H88O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15736_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15736"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6243"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15754_c0" sboTerm="SBO:0000247" id="M_cpd15754_c0" name="Isohexadecanoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C119H232O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15754_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15754"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5793"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00521_c0" sboTerm="SBO:0000247" id="M_cpd00521_c0" name="dTDP-4-oxo-6-deoxy-D-glucose [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C16H22N2O15P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -6615,22 +6587,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd12547_c0" sboTerm="SBO:0000247" id="M_cpd12547_c0" name="L-2-Lysophosphatidylethanolamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C23H46NO7P">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd12547_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd12547"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/1agpe180"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04438"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM96082"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00071_c0" sboTerm="SBO:0000247" id="M_cpd00071_c0" name="Acetaldehyde [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C2H4O">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -6958,34 +6914,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00108"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM188"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ANTHRANILATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15746_c0" sboTerm="SBO:0000247" id="M_cpd15746_c0" name="Palmitoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C119H232O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15746_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15746"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5882"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15764_c0" sboTerm="SBO:0000247" id="M_cpd15764_c0" name="Palmitoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C311H544N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15764_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15764"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8989"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7915,34 +7843,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00048"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM69"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYOX"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15753_c0" sboTerm="SBO:0000247" id="M_cpd15753_c0" name="Anteisopentadecanoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C117H228O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15753_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15753"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5623"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15771_c0" sboTerm="SBO:0000247" id="M_cpd15771_c0" name="Anteisopentadecanoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C309H540N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15771_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15771"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8312"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8905,21 +8805,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd14699_c0" sboTerm="SBO:0000247" id="M_cpd14699_c0" name="S-(3-Methylbutanoyl)-dihydrolipoamide-E [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C13H25NO2S2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd14699_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd14699"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15975"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM163705"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00050_c0" sboTerm="SBO:0000247" id="M_cpd00050_c0" name="FMN [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C17H18N4O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -8971,34 +8856,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00198"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM339"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLC-D-LACTONE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15731_c0" sboTerm="SBO:0000247" id="M_cpd15731_c0" name="1,2-di-15-methylhexadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C49H92O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15731_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15731"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6242"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15749_c0" sboTerm="SBO:0000247" id="M_cpd15749_c0" name="Isoheptadecanoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C121H236O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15749_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15749"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5792"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9235,34 +9092,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00559"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM625"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DEOXYADENOSINE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15730_c0" sboTerm="SBO:0000247" id="M_cpd15730_c0" name="1,2-dioctadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C51H96O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15730_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15730"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6248"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15748_c0" sboTerm="SBO:0000247" id="M_cpd15748_c0" name="Stearoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C123H240O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15748_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15748"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5933"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9971,27 +9800,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00881"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM704"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:DEOXYCYTIDINE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00663_c0" sboTerm="SBO:0000247" id="M_cpd00663_c0" name="Acrylyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C24H35N7O17P3S">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00663_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00663"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C24H38N7O17P3S/c1-4-15(33)52-8-7-26-14(32)5-6-27-22(36)19(35)24(2,3)10-45-51(42,43)48-50(40,41)44-9-13-18(47-49(37,38)39)17(34)23(46-13)31-12-30-16-20(25)28-11-29-21(16)31/h4,11-13,17-19,23,34-35H,1,5-10H2,2-3H3,(H,26,32)(H,27,36)(H,40,41)(H,42,43)(H2,25,28,29)(H2,37,38,39)/p-4/t13-,17-,18-,19+,23-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/POODSGUMUCVRTR-IEXPHMLFSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/pp2coa"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/prpncoa"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00894"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM78210"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM650"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ACRYLYL-COA"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -11387,34 +11195,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15733_c0" sboTerm="SBO:0000247" id="M_cpd15733_c0" name="1,2-di-12-methyltridecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C43H80O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15733_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15733"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6245"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15751_c0" sboTerm="SBO:0000247" id="M_cpd15751_c0" name="Isotetradecanoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C115H224O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15751_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15751"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5797"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00809_c0" sboTerm="SBO:0000247" id="M_cpd00809_c0" name="O-Phospho-L-homoserine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C4H8NO6P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -11485,25 +11265,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01142"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1865"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-233"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00041_e0" sboTerm="SBO:0000247" id="M_cpd00041_e0" name="L-Aspartate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C4H6NO4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00041_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00041"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C4H7NO4/c5-2(4(8)9)1-3(6)7/h2H,1,5H2,(H,6,7)(H,8,9)/p-1/t2-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/CKLJMWTZIZZHCS-REOHCLBHSA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/asp__L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00049"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM42"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:L-ASPARTATE"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -13107,21 +12868,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd14703_c0" sboTerm="SBO:0000247" id="M_cpd14703_c0" name="S-(2-Methylbutanoyl)-dihydrolipoamide-E [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C13H25NO2S2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd14703_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd14703"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15979"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5588"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00890_c0" sboTerm="SBO:0000247" id="M_cpd00890_c0" name="UDP-N-acetylmuramoyl-L-alanine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C23H33N4O20P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -13627,44 +13373,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C14145"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2784"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3-HYDROXYADIPYL-COA"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd11574_e0" sboTerm="SBO:0000247" id="M_cpd11574_e0" name="Molybdate [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="H2MoO4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd11574_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11574"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Mo.4O/q;;;2*-1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/MEFBJEMVZONFCJ-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/mobd"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06232"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1026"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-3"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd11574_c0" sboTerm="SBO:0000247" id="M_cpd11574_c0" name="Molybdate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="H2MoO4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd11574_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11574"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Mo.4O/q;;;2*-1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/MEFBJEMVZONFCJ-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/mobd"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06232"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1026"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-3"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -14576,34 +14284,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15752_c0" sboTerm="SBO:0000247" id="M_cpd15752_c0" name="Isopentadecanoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C117H228O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15752_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15752"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5794"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15770_c0" sboTerm="SBO:0000247" id="M_cpd15770_c0" name="Isopentadecanoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C309H540N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15770_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15770"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8772"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd03560_c0" sboTerm="SBO:0000247" id="M_cpd03560_c0" name="Propionyladenylate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C13H17N5O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -14931,20 +14611,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15735_c0" sboTerm="SBO:0000247" id="M_cpd15735_c0" name="1,2-di-12-methyltetradecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C45H84O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15735_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15735"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6241"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd03117_c0" sboTerm="SBO:0000247" id="M_cpd03117_c0" name="3-Oxododecanoyl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C33H52N7O18P3S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -15102,34 +14768,6 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11531"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8226"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15732_c0" sboTerm="SBO:0000247" id="M_cpd15732_c0" name="1,2-di-14-methylhexadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C49H92O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15732_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15732"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6240"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15750_c0" sboTerm="SBO:0000247" id="M_cpd15750_c0" name="Anteisoheptadecanoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C121H236O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15750_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15750"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5622"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -15863,43 +15501,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00965_c0" sboTerm="SBO:0000247" id="M_cpd00965_c0" name="Hg [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="H2Hg">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00965_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00965"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Hg"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/QSHDDOUJBYECFT-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01319"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4041"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HG0"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00531_c0" sboTerm="SBO:0000247" id="M_cpd00531_c0" name="Hg2+ [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="Hg">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00531_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00531"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Hg/q+2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/BQPIGGFYSBELGY-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/hg2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00703"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1562"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HG+2"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd15558_c0" sboTerm="SBO:0000247" id="M_cpd15558_c0" name="phosphatidylserine dioctadec-11-enoyl [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C42H76NO10P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -16038,42 +15639,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/G11160"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM824"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:KDO2-LIPID-IVA"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd01012_c0" sboTerm="SBO:0000247" id="M_cpd01012_c0" name="Cd2+ [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="Cd">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01012_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01012"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Cd/q+2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/WLZRMCYVCSSEQC-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cd2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4505"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CD+2"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd01012_e0" sboTerm="SBO:0000247" id="M_cpd01012_e0" name="Cd2+ [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="Cd">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01012_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01012"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/Cd/q+2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/WLZRMCYVCSSEQC-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cd2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4505"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CD+2"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -16445,20 +16010,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15734_c0" sboTerm="SBO:0000247" id="M_cpd15734_c0" name="1,2-di-13-methyltetradecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C45H84O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15734_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15734"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6244"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00851_c0" sboTerm="SBO:0000247" id="M_cpd00851_c0" name="trans-4-Hydroxy-L-proline [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C5H9NO3">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -16757,20 +16308,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM89939"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM158411"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:N-ACETYLD-D-MANNOSAMINE-1P"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15766_c0" sboTerm="SBO:0000247" id="M_cpd15766_c0" name="Stearoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C315H552N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15766_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15766"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM9122"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -17083,20 +16620,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00257"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM341"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUCONATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15772_c0" sboTerm="SBO:0000247" id="M_cpd15772_c0" name="Isohexadecanoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C311H544N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15772_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15772"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8765"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -17587,34 +17110,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15729_c0" sboTerm="SBO:0000247" id="M_cpd15729_c0" name="1,2-ditetradecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C43H80O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15729_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15729"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6246"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15747_c0" sboTerm="SBO:0000247" id="M_cpd15747_c0" name="Myristoyllipoteichoic acid (n=24), linked, unsubstituted [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C115H224O135P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15747_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15747"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5827"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd03496_c0" sboTerm="SBO:0000247" id="M_cpd03496_c0" name="Undecaprenyl-diphospho-N-acetylmuramoyl-(N-acetylglucosamine)-L-alanyl-D-glutaminyl-meso-2,6-diaminopimeloyl-D-alanyl-D-alanine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C95H154N9O27P2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -18040,20 +17535,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15728_c0" sboTerm="SBO:0000247" id="M_cpd15728_c0" name="1,2-dihexadecanoyl-3-O-glucopyranosyl(1-2)-O-glucopyranosyl-glycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C47H88O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15728_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15728"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6247"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd03734_c0" sboTerm="SBO:0000247" id="M_cpd03734_c0" name="Acetamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C2H5NO">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -18188,44 +17669,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd01747_c0" sboTerm="SBO:0000247" id="M_cpd01747_c0" name="Indole-3-acetamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C10H10N2O">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01747_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01747"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H10N2O/c11-10(13)5-7-6-12-9-4-2-1-3-8(7)9/h1-4,6,12H,5H2,(H2,11,13)"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/ZOAMBXDOGPRZLP-UHFFFAOYSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/iad"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02693"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2239"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-237"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00703_c0" sboTerm="SBO:0000247" id="M_cpd00703_c0" name="Indoleacetate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C10H8NO2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00703_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00703"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H9NO2/c12-10(13)5-7-6-11-9-4-2-1-3-8(7)9/h1-4,6,11H,5H2,(H,12,13)/p-1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/SEOVTRFCIGRIMH-UHFFFAOYSA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/ind3ac"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00954"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM383"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:INDOLE_ACETATE_AUXIN"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd03195_c0" sboTerm="SBO:0000247" id="M_cpd03195_c0" name="Melibiitol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C12H24O11">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -18310,20 +17753,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15541"/>
                   <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/pg181"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM162552"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd15765_c0" sboTerm="SBO:0000247" id="M_cpd15765_c0" name="Myristoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C307H536N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15765_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15765"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8894"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -18630,20 +18059,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd15769_c0" sboTerm="SBO:0000247" id="M_cpd15769_c0" name="Isotetradecanoyllipoteichoic acid (n=24), linked, N-acetyl-D-glucosamine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-24" fbc:chemicalFormula="C307H536N24O255P24">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd15769_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd15769"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8777"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd15347_c0" sboTerm="SBO:0000247" id="M_cpd15347_c0" name="2-(9Z)-hexadecenoyl-sn-glycero-3-phosphoglycerol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C22H42O9P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -18911,41 +18326,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd36025_c0" sboTerm="SBO:0000247" id="M_cpd36025_c0" name="(8S)-3&apos;,8-cyclo-7,8-dihydroguanosine 5&apos;-triphosphate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C10H12N5O14P3">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd36025_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd36025"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H16N5O14P3/c11-9-13-5-3(6(17)14-9)12-8-10(18)2(27-7(4(10)16)15(5)8)1-26-31(22,23)29-32(24,25)28-30(19,20)21/h2,4,7-8,12,16,18H,1H2,(H,22,23)(H,24,25)(H2,19,20,21)(H3,11,13,14,17)/p-4/t2?,4?,7?,8-,10?/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/HRBCPXBJAWPPIC-GZBYGQQWSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM162448"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-19179"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd19505_c0" sboTerm="SBO:0000247" id="M_cpd19505_c0" name="Precursor Z [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C10H13N5O8P">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd19505_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd19505"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H14N5O8P/c11-9-14-6-3(7(16)15-9)12-4-8(13-6)22-2-1-21-24(19,20)23-5(2)10(4,17)18/h2,4-5,8,12,17-18H,1H2,(H,19,20)(H4,11,13,14,15,16)/p-1/t2-,4-,5+,8-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/CZAKJJUNKNPTTO-AJFJRRQVSA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C18239"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1385"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:PRECURSOR-Z"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd14545_c0" sboTerm="SBO:0000247" id="M_cpd14545_c0" name="Iminoglycine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C2H2NO2">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -18983,26 +18363,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd28253_c0" sboTerm="SBO:0000247" id="M_cpd28253_c0" name="Thi-S [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C4H7N2O3R">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd28253_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd28253"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147972"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM13028"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:URM1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Thi-S"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TtuB-Sulfur-carrier-proteins"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MPT-Synthase-small-subunits"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CysO-Sulfur-carrier-proteins"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd12489_c0" sboTerm="SBO:0000247" id="M_cpd12489_c0" name="(3Z)-Decenoyl-ACP [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C21H37N2O8PRS">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -19012,43 +18372,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd12489"/>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04180"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5086"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd19503_c0" sboTerm="SBO:0000247" id="M_cpd19503_c0" name="Molybdoenzyme molybdenum cofactor [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C10H10MoN5O8PS2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd19503_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd19503"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H14N5O6PS2.Mo.2O/c11-10-14-7-4(8(16)15-10)12-3-6(24)5(23)2(21-9(3)13-7)1-20-22(17,18)19;;;/h2-3,9,12,23-24H,1H2,(H2,17,18,19)(H4,11,13,14,15,16);;;/q;+2;;/p-4/t2-,3+,9-;;;/m1.../s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/HDAJUGGARUFROU-JSUDGWJLSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C18237"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2838"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-8123"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd21288_c0" sboTerm="SBO:0000247" id="M_cpd21288_c0" name="Mast cell degranulating peptide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C19H22MoN8O15P2S2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd21288_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd21288"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C19H26N8O13P2S2.Mo.2O/c20-7-1-2-27(19(31)22-7)17-11(29)10(28)5(39-17)3-36-41(32,33)40-42(34,35)37-4-6-12(43)13(44)8-16(38-6)24-14-9(23-8)15(30)26-18(21)25-14;;;/h1-2,5-6,8,10-11,16-17,23,28-29,43-44H,3-4H2,(H,32,33)(H,34,35)(H2,20,22,31)(H4,21,24,25,26,30);;;/q;+2;;/p-4/t5-,6-,8+,10-,11-,16-,17-;;;/m1.../s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/KGCKMLSJAXDKBP-RRNIHQQDSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C20049"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM61195"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8479"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD0-1882"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19175,24 +18498,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd11209_c0" sboTerm="SBO:0000247" id="M_cpd11209_c0" name="N-Acetyl-L-citrulline [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C8H14N3O4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd11209_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11209"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C8H15N3O4/c1-5(12)11-6(7(13)14)3-2-4-10-8(9)15/h6H,2-4H2,1H3,(H,11,12)(H,13,14)(H3,9,10,15)/p-1/t6-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/WMQMIOYQXNRROC-LURJTMIESA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15532"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3314"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-7224"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd19030_c0" sboTerm="SBO:0000247" id="M_cpd19030_c0" name="(R)-2,3-Dihydroxy-3-methylbutanoate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C5H9O4">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -19225,24 +18530,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15672"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1278"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HEME_O"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd11312_c0" sboTerm="SBO:0000247" id="M_cpd11312_c0" name="hemeA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C49H54FeN4O6">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd11312_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd11312"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C49H58N4O6.Fe/c1-9-34-31(6)39-25-45-49(46(55)18-12-17-30(5)16-11-15-29(4)14-10-13-28(2)3)33(8)40(52-45)24-44-37(27-54)36(20-22-48(58)59)43(53-44)26-42-35(19-21-47(56)57)32(7)38(51-42)23-41(34)50-39;/h9,13,15,17,23-27,46,55H,1,10-12,14,16,18-22H2,2-8H3,(H4,50,51,52,53,54,56,57,58,59);/q;+2/p-4/b29-15+,30-17+,38-23-,39-25-,40-24-,41-23-,42-26-,43-26-,44-24-,45-25-;"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/ZGGYGTCPXNDTRV-ONCSLILDSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/hemeA"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15670"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM53309"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19410,69 +18697,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd28260_c0" sboTerm="SBO:0000247" id="M_cpd28260_c0" name="Thiocarboxylated-MPT-synthases [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C4H7N2O2RS">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd28260_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd28260"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM13032"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Thiocarboxylated-MPT-synthases"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd03520_c0" sboTerm="SBO:0000247" id="M_cpd03520_c0" name="Molybdopterin [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C10H11N5O6PS2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd03520_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03520"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C10H14N5O6PS2/c11-10-14-7-4(8(16)15-10)12-3-6(24)5(23)2(21-9(3)13-7)1-20-22(17,18)19/h2-3,9,12,23-24H,1H2,(H2,17,18,19)(H4,11,13,14,15,16)/p-3/t2-,3+,9-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/HPEUEJRPDGMIMY-IFQPEPLCSA-K"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05924"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1193"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-4"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd27484_c0" sboTerm="SBO:0000247" id="M_cpd27484_c0" name="MPT-Synthases [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="R">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd27484_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd27484"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM12289"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MPT-Synthases"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd26672_c0" sboTerm="SBO:0000247" id="M_cpd26672_c0" name="Carboxyadenylated-MPT-synthases [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C14H19N7O9PR">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd26672_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd26672"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM10882"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:Carboxyadenylated-MPT-synthases"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd27021_c0" sboTerm="SBO:0000247" id="M_cpd27021_c0" name="(2E)-Enoylpimeloyl-ACP-methyl-ester [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C22H36N3O11PR2S">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -19501,58 +18725,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C20258"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM30985"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-14443"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd21090_c0" sboTerm="SBO:0000247" id="M_cpd21090_c0" name="Adenylated molybdopterin [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-3" fbc:chemicalFormula="C20H23N10O12P2S2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd21090_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd21090"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C20H26N10O12P2S2/c21-14-8-16(24-3-23-14)30(4-25-8)19-11(32)10(31)5(41-19)1-38-43(34,35)42-44(36,37)39-2-6-12(45)13(46)7-18(40-6)27-15-9(26-7)17(33)29-20(22)28-15/h3-7,10-11,18-19,26,31-32,45-46H,1-2H2,(H,34,35)(H,36,37)(H2,21,23,24)(H4,22,27,28,29,33)/p-3/t5-,6-,7+,10-,11-,18-,19-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/XJXFAXLUOKQPAQ-YPRLVJTJSA-K"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C19848"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3054"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-8122"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd33647_c0" sboTerm="SBO:0000247" id="M_cpd33647_c0" name="bis(molybdenum cofactor) [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C20H20MoN10O13P2S4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd33647_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd33647"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/2C10H14N5O6PS2.Mo.O/c2*11-10-14-7-4(8(16)15-10)12-3-6(24)5(23)2(21-9(3)13-7)1-20-22(17,18)19;;/h2*2-3,9,12,23-24H,1H2,(H2,17,18,19)(H4,11,13,14,15,16);;/q;;+4;/p-8/t2*2-,3+,9-;;/m11../s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/IHRHKHANGAHFPM-BURDSJQCSA-F"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147053"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-15874"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd35194_c0" sboTerm="SBO:0000247" id="M_cpd35194_c0" name="Mo(Dtpp-mGDP)2 [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-4" fbc:chemicalFormula="C40H44MoN20O27P4S4">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd35194_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd35194"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/2C20H26N10O13P2S2.Mo.O/c2*21-19-26-13-7(15(33)28-19)24-6-12(47)11(46)5(41-17(6)25-13)2-40-45(37,38)43-44(35,36)39-1-4-9(31)10(32)18(42-4)30-3-23-8-14(30)27-20(22)29-16(8)34;;/h2*3-6,9-10,17-18,24,31-32,46-47H,1-2H2,(H,35,36)(H,37,38)(H3,22,27,29,34)(H4,21,25,26,28,33);;/q;;+4;/p-8/t2*4-,5-,6+,9-,10-,17-,18-;;/m11../s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/SPLYCLQDZVSNSU-HWCCSRDCSA-F"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM62267"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-15873"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19714,42 +18886,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02350"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM91795"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:S-ALLANTOIN"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd21167_c0" sboTerm="SBO:0000247" id="M_cpd21167_c0" name="MGD [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C20H22MoN10O15P2S2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd21167_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd21167"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C20H26N10O13P2S2.Mo.2O/c21-19-26-13-7(15(33)28-19)24-6-12(47)11(46)5(41-17(6)25-13)2-40-45(37,38)43-44(35,36)39-1-4-9(31)10(32)18(42-4)30-3-23-8-14(30)27-20(22)29-16(8)34;;;/h3-6,9-10,17-18,24,31-32,46-47H,1-2H2,(H,35,36)(H,37,38)(H3,22,27,29,34)(H4,21,25,26,28,33);;;/q;+2;;/p-4/t4-,5-,6+,9-,10-,17-,18?;;;/m1.../s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/RQPREYSMTBNTJA-USTSGIOXSA-J"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM62333"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM11740"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-582"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd01029_c0" sboTerm="SBO:0000247" id="M_cpd01029_c0" name="Base Q [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C12H16N5O3">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01029_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01029"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C12H15N5O3/c13-12-16-10-8(11(20)17-12)5(4-15-10)3-14-6-1-2-7(18)9(6)19/h1-2,4,6-7,9,14,18-19H,3H2,(H4,13,15,16,17,20)/p+1/t6-,7-,9+/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/WYROLENTHWJFLR-ACLDMZEESA-O"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01449"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM21435"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:QUEUINE"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20596,44 +19732,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00431"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM792"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:5-AMINOPENTANOATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd03453_e0" sboTerm="SBO:0000247" id="M_cpd03453_e0" name="Enterobactin [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C30H27N3O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd03453_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03453"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C30H27N3O15/c34-19-7-1-4-13(22(19)37)25(40)31-16-10-46-29(44)18(33-27(42)15-6-3-9-21(36)24(15)39)12-48-30(45)17(11-47-28(16)43)32-26(41)14-5-2-8-20(35)23(14)38/h1-9,16-18,34-39H,10-12H2,(H,31,40)(H,32,41)(H,33,42)/t16-,17-,18-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/SERBHKJMVBATSJ-BZSNNMDCSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/enter"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05821"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM883"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ENTEROBACTIN"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd03726_e0" sboTerm="SBO:0000247" id="M_cpd03726_e0" name="Fe-enterochlin [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C30H27FeN3O15">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd03726_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03726"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C30H27N3O15.Fe/c34-19-7-1-4-13(22(19)37)25(40)31-16-10-46-29(44)18(33-27(42)15-6-3-9-21(36)24(15)39)12-48-30(45)17(11-47-28(16)43)32-26(41)14-5-2-8-20(35)23(14)38;/h1-9,16-18,34-39H,10-12H2,(H,31,40)(H,32,41)(H,33,42);/q;+3/t16-,17-,18-;/m0./s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/NGILTSZTOFYVBF-UVJOBNTFSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/feenter"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06230"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7354"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90263"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21706,6 +20804,262 @@
           </rdf:RDF>
         </annotation>
       </species>
+      <species metaid="meta_M_cpd00992_c0" sboTerm="SBO:0000247" id="M_cpd00992_c0" name="1,2-Ethanediol [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C2H6O2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00992_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00992"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01380"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYCOL"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00992_e0" sboTerm="SBO:0000247" id="M_cpd00992_e0" name="1,2-Ethanediol [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C2H6O2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00992_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00992"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01380"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYCOL"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00054_e0" sboTerm="SBO:0000247" id="M_cpd00054_e0" name="L-Serine [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C3H7NO3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00054_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/ser__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:SER"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H7NO3/c4-2(1-5)3(6)7/h2,5H,1,4H2,(H,6,7)/t2-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/MTCFGRXMJLQNBG-REOHCLBHSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00065"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM53"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00054"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00085_e0" sboTerm="SBO:0000247" id="M_cpd00085_e0" name="beta-Alanine [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C3H7NO2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00085_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/ala_B"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:B-ALANINE"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H7NO2/c4-2-1-3(5)6/h1-2,4H2,(H,5,6)"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/UCMIRNVEIXFBKS-UHFFFAOYSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00099"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM144"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00085"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00132_e0" sboTerm="SBO:0000247" id="M_cpd00132_e0" name="L-Asparagine [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C4H8N2O3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00132_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/asn__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ASN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C4H8N2O3/c5-2(4(8)9)1-3(6)7/h2H,1,5H2,(H2,6,7)(H,8,9)/t2-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/DCXYFEDJOCDNAF-REOHCLBHSA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00152"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM147"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00132"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd30760_e0" sboTerm="SBO:0000247" id="M_cpd30760_e0" name="Cu+ [e0]" compartment="e0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="Cu">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd30760_e0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd30760"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cu"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C22423"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CU+"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd24604_c0" sboTerm="SBO:0000247" id="M_cpd24604_c0" name="2Fe2S iron-sulfur cluster [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="2" fbc:chemicalFormula="Fe2S2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd24604_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd24604"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/2fe2s"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CPD-6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1107419"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00334_c0" sboTerm="SBO:0000247" id="M_cpd00334_c0" name="L-Lactaldehyde [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C3H6O2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00334_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/lald__L"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LACTALD"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C3H6O2/c1-3(5)2-4/h2-3,5H,1H3/t3-/m0/s1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/inchikey/BSABBBMNWQWLLU-VKHMYHEASA-N"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00424"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2387"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00334"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00413_c0" sboTerm="SBO:0000247" id="M_cpd00413_c0" name="Glutaryl-CoA [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-5" fbc:chemicalFormula="C26H37N7O19P3S">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00413_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00413"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/glutcoa"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLUTARYL-COA"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00705_c0" sboTerm="SBO:0000247" id="M_cpd00705_c0" name="L-2-Aminoadipate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C6H10NO4">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00705_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00705"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd03045_c0" sboTerm="SBO:0000247" id="M_cpd03045_c0" name="S-(3-methylbutanoyl)-dihydrolipoamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C13H24NO2RS2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd03045_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15979"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5588"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03045"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd03046_c0" sboTerm="SBO:0000247" id="M_cpd03046_c0" name="S-(3-methylbutanoyl)-dihydrolipoamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C13H24NO2RS2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd03046_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15975"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM163705"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd03046"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd00269_c0" sboTerm="SBO:0000247" id="M_cpd00269_c0" name="2-Oxoadipate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C6H6O5">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd00269_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00269"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd16479_c0" sboTerm="SBO:0000247" id="M_cpd16479_c0" name="S-Glutaryldihydrolipoamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C13H21NO4RS2">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd16479_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd16497"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/S_gtrdhdlp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06157"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd30760_c0" sboTerm="SBO:0000247" id="M_cpd30760_c0" name="Cu+ [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="Cu">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd30760_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd30760"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/cu"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C22423"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:CU+"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="meta_M_cpd19185_c0" sboTerm="SBO:0000247" id="M_cpd19185_c0" name="7-Aminomethyl-7-carbaguanine [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C7H10N5O">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd19185_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd19185"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C16675"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:7-AMINOMETHYL-7-DEAZAGUANINE"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
     </listOfSpecies>
     <listOfParameters>
       <parameter sboTerm="SBO:0000626" id="cobra_default_lb" value="-1000" constant="true"/>
@@ -22325,33 +21679,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13335"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10297_c0" sboTerm="SBO:0000176" id="R_rxn10297_c0" name="isohexadecanoyl-lipoteichoic acid synthesis (n=24), linked, unsubstituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10297_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10297"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136293"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00402_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15736_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00046_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15754_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00165"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02000_c0" sboTerm="SBO:0000176" id="R_rxn02000_c0" name="dTDP-4-dehydro-6-deoxy-D-glucose 3,5-epimerase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -26325,36 +25652,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05505"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn08275_c0" sboTerm="SBO:0000655" id="R_rxn08275_c0" name="copper transport out via proton antiport [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08275_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08275"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CUt3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135764"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00058_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00058_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14220"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14210"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14215"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00060_c0" sboTerm="SBO:0000176" id="R_rxn00060_c0" name="porphobilinogen:(4-[2-carboxyethyl]-3-[carboxymethyl]pyrrol-2-yl)methyltransferase (hydrolysing) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -27901,41 +27198,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16950"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn08809_c0" sboTerm="SBO:0000176" id="R_rxn08809_c0" name="Lysophospholipase L1 (2-acylglycerophosphoethanolamine, n-C18:1) (periplasm) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08809_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08809"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LPLIPAL1E181pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142316"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.1.5"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd12547_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00908_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15269_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14230"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05835"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14280"/>
-            </fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01855"/>
-          </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00460_c0" sboTerm="SBO:0000176" id="R_rxn00460_c0" name="UTP:pyruvate 2-O-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -28473,32 +27735,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06465"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06470"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10307_c0" sboTerm="SBO:0000176" id="R_rxn10307_c0" name="palmitoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10307_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10307"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136303"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15746_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15764_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04280"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn12638_c0" sboTerm="SBO:0000176" id="R_rxn12638_c0" name="methionyl aminopeptidase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -29747,32 +28983,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09570"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07235"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10314_c0" sboTerm="SBO:0000176" id="R_rxn10314_c0" name="anteisopentadecanoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10314_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10314"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136310"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15753_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15771_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04280"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn09111_c0" sboTerm="SBO:0000176" id="R_rxn09111_c0" name="Phosphatidylglycerol synthase (n-C16:0) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -31197,40 +30407,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14720"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn07433_c0" sboTerm="SBO:0000176" id="R_rxn07433_c0" name="R07602 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn07433_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07433"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07602"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111209"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142262"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd14698_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14699_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09535"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09540"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn01269_c0" sboTerm="SBO:0000176" id="R_rxn01269_c0" name="Prephenate:NADP+ oxidoreductase(decarboxylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -31362,33 +30538,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03555"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10292_c0" sboTerm="SBO:0000176" id="R_rxn10292_c0" name="isoheptadecanoyl-lipoteichoic acid synthesis (n=24), linked, unsubstituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10292_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10292"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136288"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00402_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15731_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00046_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15749_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00165"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03406_c0" sboTerm="SBO:0000176" id="R_rxn03406_c0" name="Undecaprenyl-diphospho-N-acetylmuramoyl-(N-acetylglucosamine)- [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -31736,33 +30885,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05505"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10291_c0" sboTerm="SBO:0000176" id="R_rxn10291_c0" name="stearoyl-lipoteichoic acid synthesis (n=24), linked, unsubstituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10291_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10291"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136287"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00402_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15730_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00046_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15748_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00165"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08136_c0" sboTerm="SBO:0000176" id="R_rxn08136_c0" name="1,6-anhydrous-N-Acetylmuramate kinase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -32954,40 +32076,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16250"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn00668_c0" sboTerm="SBO:0000176" id="R_rxn00668_c0" name="propanoyl-CoA:NADP+ 2-oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00668_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00668"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00919"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/26456"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102415"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139008"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-9087"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.-"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.84"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19745"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14469"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15020"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00663_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00086_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11570"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn02314_c0" sboTerm="SBO:0000176" id="R_rxn02314_c0" name="ATP:D-tagatose-6-phosphate 1-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -35445,33 +34533,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16245"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn10294_c0" sboTerm="SBO:0000176" id="R_rxn10294_c0" name="isotetradecanoyl-lipoteichoic acid synthesis (n=24), linked, unsubstituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10294_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10294"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136290"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00402_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15733_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00046_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15751_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00165"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn01300_c0" sboTerm="SBO:0000176" id="R_rxn01300_c0" name="ATP:L-homoserine O-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -35633,45 +34694,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03555"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05217_c0" sboTerm="SBO:0000655" id="R_rxn05217_c0" name="TRANS-RXNBWI-115637.ce.maizeexp.L-ASPARTATE_L-ASPARTATE [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05217_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05217"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt2pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DIP5_4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt2m"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt2n"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt2r"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AGP3_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt6"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AGC1_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GAP1_5"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASPt7"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96106"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00041_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00041_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07775"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06990"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00366_c0" sboTerm="SBO:0000176" id="R_rxn00366_c0" name="CDP phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -36422,40 +35444,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07975"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05496_c0" sboTerm="SBO:0000655" id="R_rxn05496_c0" name="TRANS-RXNBWI-115637.ce.maizeexp.L-ALPHA-ALANINE_L-ALPHA-ALANINE [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05496_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05496"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ALAt2pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PUT4_1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ALAt2r"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AGP1_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ALAt2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/TAT2_1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GAP1_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/DIP5_2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95704"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5202"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00035_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00035_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06790"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00527_c0" sboTerm="SBO:0000176" id="R_rxn00527_c0" name="L-tyrosine:2-oxoglutarate aminotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -39443,40 +38431,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01885"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn07435_c0" sboTerm="SBO:0000176" id="R_rxn07435_c0" name="R07604 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn07435_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07435"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07604"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111210"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142264"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd14702_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14703_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09535"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09540"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn01678_c0" sboTerm="SBO:0000176" id="R_rxn01678_c0" name="ATP:dUDP phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -41096,38 +40050,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05770"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02310"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05619_c0" sboTerm="SBO:0000655" id="R_rxn05619_c0" name="ATP phosphohydrolase (molybdate-importing) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05619_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05619"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/MOBDabcpp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/MOBDabc"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:3.6.3.29-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.A.1.8.-"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.6.3.29"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11574_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00008_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11574_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10765"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08020_c0" sboTerm="SBO:0000176" id="R_rxn08020_c0" name="laurate-[acyl-carrier-protein] ligase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -42978,32 +41900,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00475"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn10313_c0" sboTerm="SBO:0000176" id="R_rxn10313_c0" name="isopentadecanoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10313_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10313"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136309"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15752_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15770_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04280"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00675_c0" sboTerm="SBO:0000176" id="R_rxn00675_c0" name="Propionyladenylate:CoA propionyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -43745,35 +42641,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09780"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS03560"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn06586_c0" sboTerm="SBO:0000176" id="R_rxn06586_c0" name="3-methylbutanoyl-CoA:enzyme N6-(dihydrolipoyl)lysine S-(3-methylbutanoyl)transferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn06586_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn06586"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04097"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142209"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108654"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd01882_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14699_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09545"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn12510_c0" sboTerm="SBO:0000176" id="R_rxn12510_c0" name="ATP:pantothenate 4&apos;-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -44701,33 +43568,6 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn10296_c0" sboTerm="SBO:0000176" id="R_rxn10296_c0" name="anteisopentadecanoyl-lipoteichoic acid synthesis (n=24), linked, unsubstituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10296_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10296"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136292"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00402_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15735_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00046_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15753_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00165"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00105_c0" sboTerm="SBO:0000176" id="R_rxn00105_c0" name="ATP:nicotinamide-nucleotide adenylyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -45112,37 +43952,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00140"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn05315_c0" sboTerm="SBO:0000655" id="R_rxn05315_c0" name="ZN2t4 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05315_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05315"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105279"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00034_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00205_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00034_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00205_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18420"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18410"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18035"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn05394_c0" sboTerm="SBO:0000176" id="R_rxn05394_c0" name="9-methyl-3-hydroxy-decanoyl-ACP hydro-lyase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -45166,33 +43975,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09675"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10293_c0" sboTerm="SBO:0000176" id="R_rxn10293_c0" name="anteisoheptadecanoyl-lipoteichoic acid synthesis (n=24), linked, unsubstituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10293_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10293"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136289"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00402_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15732_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00046_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15750_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00165"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03047_c0" sboTerm="SBO:0000176" id="R_rxn03047_c0" name="ATP:pantothenate 4&apos;-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -47472,37 +46254,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04280"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn02021_c0" sboTerm="SBO:0000176" id="R_rxn02021_c0" name="Hg:NADP+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn02021_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02021"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02807"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/23858"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/23859"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR107738"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:MERCURY-II-REDUCTASE-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.16.1.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00965_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00531_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08265"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn09211_c0" sboTerm="SBO:0000176" id="R_rxn09211_c0" name="Phosphatidylserine syntase (n-C18:1) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -47996,37 +46747,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13255"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13255"/>
           </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05517_c0" sboTerm="SBO:0000655" id="R_rxn05517_c0" name="cadminum transport out via antiport [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05517_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05517"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96498"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00205_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01012_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00205_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01012_e0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18420"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18410"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18035"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03249_c0" sboTerm="SBO:0000176" id="R_rxn03249_c0" name="(S)-hydroxyhexanoyl-CoA:NAD+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -48720,46 +47440,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00935"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn00569_c0" sboTerm="SBO:0000176" id="R_rxn00569_c0" name="Nitrite reductase (NAD(P)H) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00569_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00569"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NTRIR2y"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NTRIRy"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00789"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/24635"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR102063"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6377"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.1.4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K17877"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26138"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K26139"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00361"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="3" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="5" constant="true"/>
-          <speciesReference species="M_cpd00075_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="3" constant="true"/>
-          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02765"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02770"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn05341_c0" sboTerm="SBO:0000176" id="R_rxn05341_c0" name="(3R)-3-Hydroxyoctanoyl-[acyl-carrier-protein]:NADP+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -49422,33 +48102,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16345"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn10295_c0" sboTerm="SBO:0000176" id="R_rxn10295_c0" name="isopentadecanoyl-lipoteichoic acid synthesis (n=24), linked, unsubstituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10295_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10295"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136291"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00402_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15734_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00046_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15752_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00165"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00932_c0" sboTerm="SBO:0000176" id="R_rxn00932_c0" name="L-Proline,2-oxoglutarate:oxygen oxidoreductase (4-hydroxylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -49991,41 +48644,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11160"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn08808_c0" sboTerm="SBO:0000176" id="R_rxn08808_c0" name="Lysophospholipase L1 (2-acylglycerophosphoethanolamine, n-C18:0) (periplasm) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08808_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08808"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LPLIPAL1E180pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142315"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.1.5"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd12547_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00908_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01080_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:and>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14230"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS05835"/>
-              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14280"/>
-            </fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01855"/>
-          </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00558_c0" sboTerm="SBO:0000176" id="R_rxn00558_c0" name="D-glucose-6-phosphate aldose-ketose-isomerase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -50094,42 +48712,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17300"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07665"/>
           </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05297_c0" sboTerm="SBO:0000655" id="R_rxn05297_c0" name="TRANS-RXNBWI-115637.ce.maizeexp.GLT_GLT [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05297_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05297"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt2r"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt6"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt2n"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt2rpp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt7"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AGC1_1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUt2m"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100300"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00023_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07775"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06990"/>
-          </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00194_c0" sboTerm="SBO:0000176" id="R_rxn00194_c0" name="L-glutamate 1-carboxy-lyase (4-aminobutanoate-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -50720,32 +49302,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18540"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10309_c0" sboTerm="SBO:0000176" id="R_rxn10309_c0" name="stearoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10309_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10309"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136305"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15748_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15766_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04280"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn05249_c0" sboTerm="SBO:0000176" id="R_rxn05249_c0" name="FACOAL150(ISO) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -51979,32 +50535,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11560"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10315_c0" sboTerm="SBO:0000176" id="R_rxn10315_c0" name="isohexadecanoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10315_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10315"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136311"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15754_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15772_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04280"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01434_c0" sboTerm="SBO:0000176" id="R_rxn01434_c0" name="L-Citrulline:L-aspartate ligase (AMP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -53365,33 +51895,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06275"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14805"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10290_c0" sboTerm="SBO:0000176" id="R_rxn10290_c0" name="myristoyl-lipoteichoic acid synthesis (n=24), linked, unsubstituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10290_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10290"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136286"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00402_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15729_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00046_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15747_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00165"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01304_c0" sboTerm="SBO:0000176" id="R_rxn01304_c0" name="Succinyl-CoA:L-homoserine O-succinyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -55045,33 +53548,6 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn10289_c0" sboTerm="SBO:0000176" id="R_rxn10289_c0" name="palmitoyl-lipoteichoic acid synthesis (n=24), linked, unsubstituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10289_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10289"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136285"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00402_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15728_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00046_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15746_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00165"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00231_c0" sboTerm="SBO:0000176" id="R_rxn00231_c0" name="Acetamide amidohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -55605,40 +54081,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01815"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn02222_c0" sboTerm="SBO:0000176" id="R_rxn02222_c0" name="Indole-3-acetamide amidohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn02222_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02222"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AMID3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AMD2_3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03096"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/34372"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/34374"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR95814"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXNN-404"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.4"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01426"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21801"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01747_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00703_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17660"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn02093_c0" sboTerm="SBO:0000176" id="R_rxn02093_c0" name="Melibiitol galactohydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -55901,32 +54343,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12370"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn10308_c0" sboTerm="SBO:0000176" id="R_rxn10308_c0" name="myristoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10308_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10308"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136304"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15747_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15765_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04280"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn06526_c0" sboTerm="SBO:0000176" id="R_rxn06526_c0" name="protein-dithiol:NADP+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -57239,32 +55655,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00315"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn10312_c0" sboTerm="SBO:0000176" id="R_rxn10312_c0" name="isotetradecanoyl-lipoteichoic acid synthesis (n=24), linked, N-acetylglucosamine substituted [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn10312_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn10312"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR136308"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.8.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00037_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15751_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00014_c0" stoichiometry="24" constant="true"/>
-          <speciesReference species="M_cpd15769_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04280"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00674_c0" sboTerm="SBO:0000176" id="R_rxn00674_c0" name="Propanoate:CoA ligase (AMP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -57391,35 +55781,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01805"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn06335_c0" sboTerm="SBO:0000176" id="R_rxn06335_c0" name="(S)-2-methylbutanoyl-CoA:enzyme N6-(dihydrolipoyl)lysine S-(2-methylbutanoyl)transferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn06335_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn06335"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03174"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135216"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108002"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00760_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd14703_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09545"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn08849_c0" sboTerm="SBO:0000176" id="R_rxn08849_c0" name="Lysophospholipase L2 (2-acylglycerophosphoglycerol, n-C16:1) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -58830,34 +57191,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12165"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn45996_c0" sboTerm="SBO:0000176" id="R_rxn45996_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn45996_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn45996"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/49581"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR121181"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-17809"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/4.6.1.17"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd36025_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19505_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10785"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_thiazol_synth" sboTerm="SBO:0000176" id="R_thiazol_synth" name="thiazole synthase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -58925,34 +57258,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09675"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09675"/>
           </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn26361_c0" sboTerm="SBO:0000176" id="R_rxn26361_c0" name="molybdenum cofactor cytidylyltransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn26361_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn26361"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/31338"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR114874"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-6254"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.76"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00052_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19503_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd21288_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10335"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn47768_c0" sboTerm="SBO:0000176" id="R_rxn47768_c0" name="3-oxo-glutaryl-[acp] methyl ester synthase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -59126,34 +57431,6 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn15972_c0" sboTerm="SBO:0000176" id="R_rxn15972_c0" name="N-acetyl-L-citrulline amidohydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn15972_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn15972"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09107"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR112547"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-7933"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.16"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11209_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00029_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00274_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14780"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn15466_c0" sboTerm="SBO:0000176" id="R_rxn15466_c0" name="(R)-2,3-Dihydroxy-3-methylbutanoate:NADP+ oxidoreductase (isomerizing) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -59189,31 +57466,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19365"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19365"/>
           </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn05121_c0" sboTerm="SBO:0000176" id="R_rxn05121_c0" name="R07412 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05121_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05121"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07412"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100591"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K02259"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd11313_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd11312_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19280"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn14427_c0" sboTerm="SBO:0000185" id="R_rxn14427_c0" name="Nitrate reductase cytochrome-c type (2 protons translocated) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -59523,35 +57775,6 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn09003_c0" sboTerm="SBO:0000185" id="R_rxn09003_c0" name="Nitrate reductase (Menaquinol-8) (periplasm) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn09003_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09003"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NO3R2"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NO3R2pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101988"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00209_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15499_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00075_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15500_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02775"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn14412_c0" sboTerm="SBO:0000185" id="R_rxn14412_c0" name="cytochrome-c reductase (ubiquinol: 2 protons) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -59708,123 +57931,6 @@
           </fbc:and>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn09001_c0" sboTerm="SBO:0000185" id="R_rxn09001_c0" name="Nitrate reductase (Ubiquinol-8) (periplasm) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn09001_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09001"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NO3R1pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NO3R1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101986"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.99.4"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00209_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15561_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00075_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd15560_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02775"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn14415_c0" sboTerm="SBO:0000655" id="R_rxn14415_c0" name="cytochrome-c oxidase (2 protons translocated) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn14415_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn14415"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR137923"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00007_c0" stoichiometry="0.5" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="4" constant="true"/>
-          <speciesReference species="M_cpd00110_c0" stoichiometry="3" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00109_c0" stoichiometry="3" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:and>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19300"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19310"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19315"/>
-          </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn41896_c0" sboTerm="SBO:0000176" id="R_rxn41896_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn41896_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn41896"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/26334"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR122272"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8342"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19505_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd28260_c0" stoichiometry="2" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="4" constant="true"/>
-          <speciesReference species="M_cpd03520_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd28253_c0" stoichiometry="2" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10775"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn21729_c0" sboTerm="SBO:0000176" id="R_rxn21729_c0" name="adenylyltransferase and sulfurtransferase MOCS3 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn21729_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn21729"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11361"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.80"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd26672_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27484_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10795"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn21862_c0" sboTerm="SBO:0000176" id="R_rxn21862_c0" name="RXN-11481.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -59876,67 +57982,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06645"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn16583_c0" sboTerm="SBO:0000176" id="R_rxn16583_c0" name="adenylyl-molybdopterin:molybdate molybdate transferase (AMP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn16583_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn16583"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09735"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/35048"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/35050"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR139727"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8348"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.10.1.1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K03750"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K15376"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd11574_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd21090_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00018_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19503_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10325"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn44539_c0" sboTerm="SBO:0000176" id="R_rxn44539_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn44539_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn44539"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR120102"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-16456"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.77"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00038_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd33647_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd35194_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07810"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn16609_c0" sboTerm="SBO:0000176" id="R_rxn16609_c0" name="ATP:(KDO)-lipid IVA 3-deoxy-alpha-D-manno-oct-2-ulopyranose 4-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -60175,33 +58220,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06240"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn24830_c0" sboTerm="SBO:0000176" id="R_rxn24830_c0" name="thiocarboxylated molybdopterin synthase:cyclic pyranopterin monophosphate sulfurtransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn24830_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn24830"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-8342"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.12"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd03520_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27484_c0" stoichiometry="2" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19505_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd28260_c0" stoichiometry="2" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10775"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn42709_c0" sboTerm="SBO:0000176" id="R_rxn42709_c0" name="[c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -60264,93 +58282,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07140"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn26021_c0" sboTerm="SBO:0000176" id="R_rxn26021_c0" name="MobA [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn26021_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn26021"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR114873"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-262"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.7.77"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00038_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19503_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd21167_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07810"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn41683_c0" sboTerm="SBO:0000176" id="R_rxn41683_c0" name="[c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn41683_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn41683"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR140619"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-16457"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd03520_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd19503_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd33647_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07810"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn07436_c0" sboTerm="SBO:0000176" id="R_rxn07436_c0" name="7-aminomethyl-7-carbaguanine:NADP+ oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn07436_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn07436"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07605"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/13412"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96521"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135611"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-4022"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.1.13"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09457"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06879"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd01029_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="3" constant="true"/>
-          <speciesReference species="M_cpd14718_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04330"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn16826_c0" sboTerm="SBO:0000176" id="R_rxn16826_c0" name="Ureidoacrylate amidohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -60478,36 +58409,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16090"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn03396_c0" sboTerm="SBO:0000176" id="R_rxn03396_c0" name="R04989 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn03396_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn03396"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04989"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109273"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.14.13.-"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00007_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd03446_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd03447_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13875"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn15296_c0" sboTerm="SBO:0000176" id="R_rxn15296_c0" name="6-Phospho-D-gluconate hydro-lyase(2-dehydro-3-deoxy-6-phospho-D-gluconate-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -61107,90 +59008,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04415"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn09304_c0" sboTerm="SBO:0000655" id="R_rxn09304_c0" name="TRANS-RXN-244.cp [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn09304_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09304"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/THRt2pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/THRt3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104851"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN0-0244"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00161_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00161_e0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10880"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn08722_c0" sboTerm="SBO:0000655" id="R_rxn08722_c0" name="TRANS-RXN-242.cp [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08722_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08722"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HOMt"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HOMt2pp"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/35028"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100676"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN-242"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00227_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00227_e0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10880"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn21863_c0" sboTerm="SBO:0000176" id="R_rxn21863_c0" name="RXN-11482.c [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn21863_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn21863"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11482"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.10"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27021_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd21088_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16200"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn40037_c0" sboTerm="SBO:0000176" id="R_rxn40037_c0" name="L-aspartate-4-semialdehyde hydro-lyase [adding pyruvate and cyclizing; (2S,4S)-4-hydroxy-2,3,4,5-tetrahydrodipicolinate-forming] [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -61221,33 +59038,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00820"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10200"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn21859_c0" sboTerm="SBO:0000176" id="R_rxn21859_c0" name="RXN-11478.c [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn21859_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn21859"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11478"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.10"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27020_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd27180_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16200"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn20643_c0" sboTerm="SBO:0000176" id="R_rxn20643_c0" name="thiC (gene name) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -61315,35 +59105,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14625"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn17731_c0" sboTerm="SBO:0000176" id="R_rxn17731_c0" name="biotin synthase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn17731_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn17731"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.8.1.6-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.6"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00017_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00084_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01311_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00035_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00060_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00104_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd03091_c0" stoichiometry="2" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06245"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn21860_c0" sboTerm="SBO:0000176" id="R_rxn21860_c0" name="RXN-11479.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -61448,31 +59209,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18670"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19275"/>
           </fbc:and>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn16828_c0" sboTerm="SBO:0000176" id="R_rxn16828_c0" name="R09982 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn16828_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn16828"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09982"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR113373"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09021"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd21486_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd21482_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16095"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn15750_c0" sboTerm="SBO:0000176" id="R_rxn15750_c0" name="R08570 [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -62196,28 +59932,6 @@
           <speciesReference species="M_cpd00040_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
-      <reaction metaid="meta_R_rxn08502_e0" sboTerm="SBO:0000176" id="R_rxn08502_e0" name="enterobactin Fe(III) binding (spontaneous) [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08502_e0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08502"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/FEENTERexs"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135812"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd03453_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd10516_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd03726_e0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-      </reaction>
       <reaction metaid="meta_R_rxn08428_c0" sboTerm="SBO:0000655" id="R_rxn08428_c0" name="ethanol transport via diffusion (extracellular to periplasm) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -62604,11 +60318,6 @@
           <speciesReference species="M_cpd00128_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction metaid="meta_R_EX_cpd00041_e0" sboTerm="SBO:0000627" id="R_EX_cpd00041_e0" name="Exchange for L-Aspartate [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd00041_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
       <reaction metaid="meta_R_EX_cpd00244_e0" sboTerm="SBO:0000627" id="R_EX_cpd00244_e0" name="Exchange for Ni2+ [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd00244_e0" stoichiometry="1" constant="true"/>
@@ -62689,11 +60398,6 @@
           <speciesReference species="M_cpd00116_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction metaid="meta_R_EX_cpd03726_e0" sboTerm="SBO:0000627" id="R_EX_cpd03726_e0" name="Exchange for Fe-enterochlin [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd03726_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
       <reaction metaid="meta_R_EX_cpd00098_e0" sboTerm="SBO:0000627" id="R_EX_cpd00098_e0" name="Exchange for Choline [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd00098_e0" stoichiometry="1" constant="true"/>
@@ -62742,11 +60446,6 @@
       <reaction metaid="meta_R_EX_cpd00058_e0" sboTerm="SBO:0000627" id="R_EX_cpd00058_e0" name="Exchange for Cu2+ [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd00058_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
-      <reaction metaid="meta_R_EX_cpd03453_e0" sboTerm="SBO:0000627" id="R_EX_cpd03453_e0" name="Exchange for Enterobactin [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd03453_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
       <reaction metaid="meta_R_EX_cpd00081_e0" sboTerm="SBO:0000627" id="R_EX_cpd00081_e0" name="Exchange for Sulfite [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -62819,11 +60518,6 @@
           <speciesReference species="M_cpd00048_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction metaid="meta_R_EX_cpd01012_e0" sboTerm="SBO:0000627" id="R_EX_cpd01012_e0" name="Exchange for Cd2+ [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd01012_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
       <reaction metaid="meta_R_EX_cpd01414_e0" sboTerm="SBO:0000627" id="R_EX_cpd01414_e0" name="Exchange for Tetrathionate [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd01414_e0" stoichiometry="1" constant="true"/>
@@ -62847,11 +60541,6 @@
       <reaction metaid="meta_R_EX_cpd00367_e0" sboTerm="SBO:0000627" id="R_EX_cpd00367_e0" name="Exchange for Cytidine [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
         <listOfReactants>
           <speciesReference species="M_cpd00367_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-      </reaction>
-      <reaction metaid="meta_R_EX_cpd11574_e0" sboTerm="SBO:0000627" id="R_EX_cpd11574_e0" name="Exchange for Molybdate [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <listOfReactants>
-          <speciesReference species="M_cpd11574_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
       <reaction metaid="meta_R_EX_cpd00184_e0" sboTerm="SBO:0000627" id="R_EX_cpd00184_e0" name="Exchange for Thymidine [e0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -63334,28 +61023,6 @@
         <listOfProducts>
           <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
           <speciesReference species="M_cpd00069_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-      </reaction>
-      <reaction metaid="meta_R_rxn05669_c0" sboTerm="SBO:0000185" id="R_rxn05669_c0" name="L-Valine:proton symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn05669_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/VALt2r"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR105188"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00156_e0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00156_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_rxn05242_c0" sboTerm="SBO:0000185" id="R_rxn05242_c0" name="L-Valine:sodium symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -64283,34 +61950,6 @@
           <speciesReference species="M_cpd23538_e0" stoichiometry="1" constant="true"/>
         </listOfReactants>
       </reaction>
-      <reaction metaid="meta_R_rxn00196_c0" sboTerm="SBO:0000176" id="R_rxn00196_c0" name="2,5-dioxopentanoate:NADP+ 5-oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00196_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.26"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.3"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00264"/>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00196_c0"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00006_c0" stoichiometry="2" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00024_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13390"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00275_c0" sboTerm="SBO:0000176" id="R_rxn00275_c0" name="Glycine:2-oxoglutarate aminotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -64335,35 +61974,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS01650"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn00309_c0" sboTerm="SBO:0000176" id="R_rxn00309_c0" name="L-Lysine:NAD+ 6-oxidoreductase (deaminating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00309_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.4.1.18"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00446"/>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00309_c0"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00039_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02522_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17755"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00320_c0" sboTerm="SBO:0000176" id="R_rxn00320_c0" name="lysine racemase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
@@ -65152,34 +62762,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09235"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn01032_c0" sboTerm="SBO:0000176" id="R_rxn01032_c0" name="Benzaldehyde:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01032_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.28"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.29"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01419"/>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01032_c0"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00003_c0" stoichiometry="2" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_cpd00153_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18975"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01042_c0" sboTerm="SBO:0000176" id="R_rxn01042_c0" name="D-xylose:NADP+ 1-oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
@@ -67075,6 +64657,1241 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04765"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_cpd00992_trans" sboTerm="SBO:0000658" id="R_cpd00992_trans" name="Transport of 1,2-Ethanediol" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00992_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00992_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+      </reaction>
+      <reaction metaid="meta_R_EX_cpd00054_e0" sboTerm="SBO:0000627" id="R_EX_cpd00054_e0" name="Exchange of L-Serine [e0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00054_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_EX_cpd00085_e0" sboTerm="SBO:0000627" id="R_EX_cpd00085_e0" name="Exchange of beta-Alanine [e0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00085_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_EX_cpd00132_e0" sboTerm="SBO:0000627" id="R_EX_cpd00132_e0" name="Exchange of L-Asparagine [e0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00132_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_EX_cpd00992_e0" sboTerm="SBO:0000627" id="R_EX_cpd00992_e0" name="Exchange of 1,2-Ethanediol [e0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00992_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_EX_cpd30760_e0" sboTerm="SBO:0000627" id="R_EX_cpd30760_e0" name="Exchange of Cu+ [e0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd30760_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+      </reaction>
+      <reaction metaid="meta_R_isc_split" sboTerm="SBO:0000176" id="R_isc_split" name="Oxidative cleavage of 4Fe4S by sufA" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd24682_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="8" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd24604_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd10516_c0" stoichiometry="4" constant="true"/>
+          <speciesReference species="M_cpd00239_c0" stoichiometry="4" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="2" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12845"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_mmal_sald_redox" sboTerm="SBO:0000176" id="R_mmal_sald_redox" name="2-methyl-3-oxopropanoate:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_mmal_sald_redox">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00876_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00287_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02430"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06835"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn00333_c0" sboTerm="SBO:0000176" id="R_rxn00333_c0" name="Glycolate:oxygen 2-oxidoreductase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn00333_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLYCTO1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc.reaction/META:RXN-969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.3.15"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00475"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100338"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00333"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00139_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00025_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00040_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn00346_c0" sboTerm="SBO:0000176" id="R_rxn00346_c0" name="L-aspartate 1-carboxy-lyase (beta-alanine-forming)" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn00346_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ASP1DC"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ASPDECARBOX-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18933"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K24264"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01579"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01580"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K18966"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00489"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96077"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00346"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00041_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00085_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17340"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn00452_c0" sboTerm="SBO:0000176" id="R_rxn00452_c0" name="S-Adenosyl-L-methionine:L-homocysteine S-methyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn00452_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HCYSMT"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/SAM4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/MHT1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:HOMOCYSTEINE-S-METHYLTRANSFERASE-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.1.1.10"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00547"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00650"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100577"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138506"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/21823"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00452"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00017_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00135_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00019_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00060_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17710"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn00509_c0" sboTerm="SBO:0000176" id="R_rxn00509_c0" name="4-Oxobutanoate:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn00509_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00714"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/SSALy"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-5293"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/SUCCSEMIALDDEHYDROG-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.16"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00199_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00036_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13390"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18975"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction id="R_rxn01011_c0" name="Glycerate:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00145_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00223_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02430"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06555"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19525"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09235"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction id="R_rxn01013_c0" name="Glycerate:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <listOfReactants>
+          <speciesReference species="M_cpd00145_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00223_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02430"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06835"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09245"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14895"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01053_c0" sboTerm="SBO:0000176" id="R_rxn01053_c0" name="(S)-lactaldehyde:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01053_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LCADm"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LCAD"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/LCADi"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/ALD5_2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:LACTALDDEHYDROG-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALDEHYDE-DEHYDROGENASE-NADORNOP+-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.21"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.22"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07248"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K19266"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01446"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101018"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/14280"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/14278"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01053"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00334_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00159_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13390"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02125"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01305_c0" sboTerm="SBO:0000176" id="R_rxn01305_c0" name="1,2-Ethanediol:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01305_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01305"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01781"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLYCOLALDREDUCT-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.77"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.1"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00229_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00992_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02430"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06555"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn01802_c0" sboTerm="SBO:0000176" id="R_rxn01802_c0" name="Glutaryl-CoA:FAD 2,3-oxidoreductase (decarboxylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn01802_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01802"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUTCOADHc"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02487"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00413_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00015_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00650_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00982_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS07620"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn02226_c0" sboTerm="SBO:0000176" id="R_rxn02226_c0" name="2-Amino-6-oxohexanoate:NAD+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn02226_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02226"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/AASAD3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03102"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:1.2.1.31-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALLYSINE-DEHYDROG-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.1.31"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd02522_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00705_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13390"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02125"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn02271_c0" sboTerm="SBO:0000176" id="R_rxn02271_c0" name="(S)-2-methylbutanoyl-CoA:enzyme N6-(dihydrolipoyl)lysine S-(2-methylbutanoyl)transferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn02271_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03174"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135216"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108002"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02271"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00760_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd03045_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09545"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn02867_c0" sboTerm="SBO:0000176" id="R_rxn02867_c0" name="3-methylbutanoyl-CoA:enzyme N6-(dihydrolipoyl)lysine S-(3-methylbutanoyl)transferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn02867_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.168"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09699"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R04097"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108654"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02867"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd01882_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd03046_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09545"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05039_c0" sboTerm="SBO:0000176" id="R_rxn05039_c0" name="5-amino-6-(5-phosphoribitylamino)uracil phosphatase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05039_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/PMDPHT"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RIBOPHOSPHAT-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.104"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K22912"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K20861"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21063"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K20860"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K20862"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K21064"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07280"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96145"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05039"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd02720_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd02882_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00740"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05464_c0" sboTerm="SBO:0000176" id="R_rxn05464_c0" name="Octadecanoyl-ACP:NADP+ oxidoreductase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05464_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/EAR180y"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00208"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K07512"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K10780"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01404"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR97860"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05464"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11572_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd15268_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16200"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05495_c0" sboTerm="SBO:0000185" id="R_rxn05495_c0" name="beta-Alanine transport via sodium symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05495_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05495"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00085_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00085_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10880"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05684_c0" sboTerm="SBO:0000655" id="R_rxn05684_c0" name="TRANS-RXN-242.cp [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05684_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HOMt"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/HOMt2pp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN-242"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100676"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/35028"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05684"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00227_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00227_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10880"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn05894_c0" sboTerm="SBO:0000176" id="R_rxn05894_c0" name="Nitrate:ferredoxin oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn05894_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn05894_c0"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00791"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.7.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00209_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11620_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="2" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00075_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11621_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15795"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn06937_c0" sboTerm="SBO:0000176" id="R_rxn06937_c0" name="L-glutamate:tRNA(Glu) ligase (AMP-forming)" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn06937_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLUTRS"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/6.1.1.17"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K01885"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09698"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K14163"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R05578"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR145083"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn06937"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11912_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00012_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00018_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd12227_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06345"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn09247_c0" sboTerm="SBO:0000185" id="R_rxn09247_c0" name="L-Serine transport via sodium symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn09247_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09247"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00054_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00054_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10880"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn09306_c0" sboTerm="SBO:0000655" id="R_rxn09306_c0" name="TRANS-RXN-244.cp [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn09306_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/THRt2pp"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/THRt3"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN0-0244"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR104851"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn09306"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00161_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00161_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10880"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn11955_c0" sboTerm="SBO:0000176" id="R_rxn11955_c0" name="2-Oxoadipate:lipoamide 2-oxidoreductase (decarboxylating and acceptor-succinylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn11955_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn11955"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01940"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00269_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd16479_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09110"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09115"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn11960_c0" sboTerm="SBO:0000176" id="R_rxn11960_c0" name="Glutaryl-CoA:dihydrolipoamide S-succinyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn11960_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn11960"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02571"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.3.1.61"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd16479_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00010_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00413_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd16584_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09115"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13970"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn12191_c0" sboTerm="SBO:0000176" id="R_rxn12191_c0" name="Choline:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn12191_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01043"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R08558"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-12582"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00447_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00098_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02430"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06835"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13395"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11855"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn12224_c0" sboTerm="SBO:0000176" id="R_rxn12224_c0" name="R04989 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn12224_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.14.13.-"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R12658"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR109273"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn12224"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03446_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03447_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13875"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn13688_c0" sboTerm="SBO:0000655" id="R_rxn13688_c0" name="cytochrome-c oxidase (2 protons translocated) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn13688_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn13688"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00007_c0" stoichiometry="0.5" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="4" constant="true"/>
+          <speciesReference species="M_cpd00110_c0" stoichiometry="2" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_e0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00109_c0" stoichiometry="2" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19300"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19310"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS19315"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn14045_c0" sboTerm="SBO:0000176" id="R_rxn14045_c0" name="biotin synthase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn14045_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2.8.1.6-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.8.1.6"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn17731"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00017_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd01311_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd24604_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd11620_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00060_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00104_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03091_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd11621_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd10515_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00239_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06245"/>
+            <fbc:or>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12845"/>
+              <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12840"/>
+            </fbc:or>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn15341_c0" sboTerm="SBO:0000176" id="R_rxn15341_c0" name="Lactaldehyde:NAD+ 1-oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn15341_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn15341"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02531"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R10715"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.1"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.21"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00334_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00428_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02430"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06555"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn16141_c0" sboTerm="SBO:0000176" id="R_rxn16141_c0" name="4-Hydroxybutanoate:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn16141_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn16141"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09281"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11002"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/RXN-6903"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00199_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00728_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02430"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06835"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09245"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn26398_c0" sboTerm="SBO:0000176" id="R_rxn26398_c0" name="R09982 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn26398_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09021"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R09982"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR113373"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn26398"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd21482_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd21486_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16095"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn29147_c0" sboTerm="SBO:0000587" id="R_rxn29147_c0" name="copper transport out via proton antiport [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn29147_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn29147"/>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/CUtex"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:TRANS-RXN0-280"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd30760_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd30760_e0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14210"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS14215"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn34491_c0" sboTerm="SBO:0000185" id="R_rxn34491_c0" name="L-Asparagine transport via sodium symport" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn34491_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn34491"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00132_e0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00971_e0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00971_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00132_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS10880"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn35550_c0" sboTerm="SBO:0000176" id="R_rxn35550_c0" name="R07604 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn35550_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07604"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111210"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142264"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn35550"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd14702_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03045_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09540"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09535"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn35552_c0" sboTerm="SBO:0000176" id="R_rxn35552_c0" name="R07602 [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn35552_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.2.4.4"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K11381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00166"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K00167"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07602"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR111209"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR142262"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn35552"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd14698_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd14954_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00056_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd03046_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:and>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09540"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS09535"/>
+          </fbc:and>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn36075_c0" sboTerm="SBO:0000176" id="R_rxn36075_c0" name="Propanal:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn36075_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn36075"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ALCOHOL-DEHYDROGENASE-NADP+-RXN"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.2"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.71"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd03559_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00371_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02430"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06835"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn39829_c0" sboTerm="SBO:0000176" id="R_rxn39829_c0" name="7-aminomethyl-7-carbaguanine:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn39829_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN0-4022"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.7.1.13"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K09457"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.orthology/K06879"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R07605"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR135611"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR96521"/>
+                  <rdf:li rdf:resource="https://identifiers.org/rhea/13412"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn39829"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd19185_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="2" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="3" constant="true"/>
+          <speciesReference species="M_cpd14718_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS04330"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn43611_c0" sboTerm="SBO:0000176" id="R_rxn43611_c0" name="1,2-Ethanediol:NADP+ oxidoreductase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn43611_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn43611"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14023"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.2"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00229_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00005_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00006_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00992_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02430"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18005"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06835"/>
+          </fbc:or>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn45550_c0" sboTerm="SBO:0000176" id="R_rxn45550_c0" name="RXN-11482.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn45550_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11482"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn45550"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd27021_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd21088_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16200"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn46124_c0" sboTerm="SBO:0000176" id="R_rxn46124_c0" name="RXN-11478.c [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_default_ub" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn46124_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-11478"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.3.1.9"/>
+                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn46124"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd27020_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd27180_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16200"/>
         </fbc:geneProductAssociation>
       </reaction>
     </listOfReactions>
@@ -69361,19 +68178,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS14220" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14220" fbc:name="MASE_RS14220" fbc:label="G_MASE_RS14220">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS14220">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950443.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS14210" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14210" fbc:name="MASE_RS14210" fbc:label="G_MASE_RS14210">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -71402,19 +70206,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS11570" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11570" fbc:name="MASE_RS11570" fbc:label="G_MASE_RS11570">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS11570">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949931.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS16210" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16210" fbc:name="MASE_RS16210" fbc:label="G_MASE_RS16210">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -71981,19 +70772,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014948216.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07775" fbc:name="MASE_RS07775" fbc:label="G_MASE_RS07775">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS07775">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949187.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -74041,19 +72819,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10765" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10765" fbc:name="MASE_RS10765" fbc:label="G_MASE_RS10765">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS10765">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949770.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS11125" sboTerm="SBO:0000243" fbc:id="G_MASE_RS11125" fbc:name="MASE_RS11125" fbc:label="G_MASE_RS11125">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -74847,45 +73612,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18420" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18420" fbc:name="MASE_RS18420" fbc:label="G_MASE_RS18420">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS18420">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951213.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18410" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18410" fbc:name="MASE_RS18410" fbc:label="G_MASE_RS18410">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS18410">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951211.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS18035" sboTerm="SBO:0000243" fbc:id="G_MASE_RS18035" fbc:name="MASE_RS18035" fbc:label="G_MASE_RS18035">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS18035">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951137.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS07605" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07605" fbc:name="MASE_RS07605" fbc:label="G_MASE_RS07605">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -75608,19 +74334,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949196.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS08265" sboTerm="SBO:0000243" fbc:id="G_MASE_RS08265" fbc:name="MASE_RS08265" fbc:label="G_MASE_RS08265">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS08265">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949281.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -77708,19 +76421,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10785" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10785" fbc:name="MASE_RS10785" fbc:label="G_MASE_RS10785">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS10785">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949774.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS00460" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00460" fbc:name="MASE_RS00460" fbc:label="G_MASE_RS00460">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -77734,19 +76434,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10335" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10335" fbc:name="MASE_RS10335" fbc:label="G_MASE_RS10335">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS10335">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949687.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS00470" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00470" fbc:name="MASE_RS00470" fbc:label="G_MASE_RS00470">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -77754,19 +76441,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947795.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS19280" sboTerm="SBO:0000243" fbc:id="G_MASE_RS19280" fbc:name="MASE_RS19280" fbc:label="G_MASE_RS19280">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS19280">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693893.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -78170,58 +76844,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951386.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10775" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10775" fbc:name="MASE_RS10775" fbc:label="G_MASE_RS10775">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS10775">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949772.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10795" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10795" fbc:name="MASE_RS10795" fbc:label="G_MASE_RS10795">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS10795">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949776.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS10325" sboTerm="SBO:0000243" fbc:id="G_MASE_RS10325" fbc:name="MASE_RS10325" fbc:label="G_MASE_RS10325">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS10325">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949685.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS07810" sboTerm="SBO:0000243" fbc:id="G_MASE_RS07810" fbc:name="MASE_RS07810" fbc:label="G_MASE_RS07810">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS07810">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014949194.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -78770,6 +77392,9 @@
       <fbc:geneProduct fbc:id="G_MASE_RS05160" fbc:name="G_MASE_RS05160" fbc:label="G_MASE_RS05160"/>
       <fbc:geneProduct fbc:id="G_MASE_RS05045" fbc:name="G_MASE_RS05045" fbc:label="G_MASE_RS05045"/>
       <fbc:geneProduct fbc:id="G_MASE_RS04765" fbc:name="G_MASE_RS04765" fbc:label="G_MASE_RS04765"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS12845" fbc:name="G_MASE_RS12845" fbc:label="G_MASE_RS12845"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS17710" fbc:name="G_MASE_RS17710" fbc:label="G_MASE_RS17710"/>
+      <fbc:geneProduct fbc:id="G_MASE_RS00740" fbc:name="G_MASE_RS00740" fbc:label="G_MASE_RS00740"/>
     </fbc:listOfGeneProducts>
   </model>
 </sbml>


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds `rxn06937_c0` with GPR `MASE_RS06345`; see [MIT1002 PR #135](https://github.com/C-CoMP-STC/GEM-mit1002/pull/135)
- Adds `rxn00346_c0` with GPR `MASE_RS17340`; see [MIT1002 PR #138](https://github.com/C-CoMP-STC/GEM-mit1002/pull/138)
- Removes `rxn15972_c0` and `cpd11209_c0` because `rxn00469_c0` is already in model; see [MIT1002 PR #143](https://github.com/C-CoMP-STC/GEM-mit1002/pull/143)
- Adds `rxn00333_c0` with GPR `MASE_RS17475`; see [MIT1002 PR #176](https://github.com/C-CoMP-STC/GEM-mit1002/pull/176)
- Adds `rxn05464_c0` with GPR: `MASE_RS16200`; see [MIT1002 PR #194](https://github.com/C-CoMP-STC/GEM-mit1002/pull/194)
- Replaces `rxn14415_c0` with `rxn13688_c0`, GPR: `MASE_RS19300 and MASE_RS19310 and MASE_RS19315`; see [MIT1002 PR #274](https://github.com/C-CoMP-STC/GEM-mit1002/pull/274)
- Removes `rxn09001_c0` and `rxn09003_c0`; see [MIT1002 PR #275](https://github.com/C-CoMP-STC/GEM-mit1002/pull/275)
- Adds `cpd24604_c0`, `MASE_RS12845`, and `isc_split` (GPR: `MASE_RS12845`); see [MIT1002 PR #277](https://github.com/C-CoMP-STC/GEM-mit1002/pull/277)
- Replaces `rxn17731_c0` with `rxn14045_c0` (GPR: `MASE_RS06245 and (MASE_RS12845 or MASE_RS12840)`); see [MIT1002 PR #277](https://github.com/C-CoMP-STC/GEM-mit1002/pull/277)
- Removes `EX_cpd11574_e0`, `rxn05619_c0`, `rxn16583_c0`, `rxn21729_c0`, `rxn24830_c0`, `rxn26021_c0`, `rxn26361_c0`, `rxn41683_c0`, `rxn41896_c0`, `rxn44539_c0`, `rxn45996_c0`, `cpd03520_c0`, `cpd11574_c0`, `cpd11574_e0`, `cpd19503_c0`, `cpd19505_c0`, `cpd21090_c0`, `cpd21167_c0`, `cpd21288_c0`, `cpd26672_c0`, `cpd27484_c0`, `cpd28253_c0`, `cpd28260_c0`, `cpd33647_c0`, `cpd35194_c0`, `cpd36025_c0`, `MASE_RS07810`, `MASE_RS10325`, `MASE_RS10335`, `MASE_RS10765`, `MASE_RS10775`, `MASE_RS10785`, and `MASE_RS10795`; see MIT1002 PRs [#278](https://github.com/C-CoMP-STC/GEM-mit1002/pull/278) and [#301](https://github.com/C-CoMP-STC/GEM-mit1002/pull/301)
- Removes `rxn08808_c0`, `rxn08809_c0`, and `cpd12547_c0`; see [MIT1002 PR #279](https://github.com/C-CoMP-STC/GEM-mit1002/pull/279)
- Replaces `cpd01029_c0` with `cpd19185_c0`, `cpd14699_c0` with `cpd03046_c0`, `cpd14703_c0` with `cpd03045_c0`, `rxn03396_c0` with `rxn12224_c0`, `rxn06335_c0` with `rxn02271_c0`, `rxn06586_c0` with `rxn02867_c0`, `rxn07433_c0` with `rxn35552_c0`, `rxn07435_c0` with `rxn35550_c0`, `rxn07436_c0` with `rxn39829_c0`, and `rxn16828_c0` with `rxn26398_c0`; see [MIT1002 PR #280](https://github.com/C-CoMP-STC/GEM-mit1002/pull/280)
- Removes `rxn05121_c0`, `rxn08502_e0`, `EX_cpd03726_e0`, `EX_cpd03453_e0`, `cpd03453_e0`, `cpd03726_e0`, `cpd11312_c0`, and `MASE_RS19280`; see [MIT1002 PR #280](https://github.com/C-CoMP-STC/GEM-mit1002/pull/280)
- Adds `cpd00054_e0`, `cpd00085_e0`, `cpd00132_e0`, `EX_cpd00054_e0`, `EX_cpd00085_e0`, `EX_cpd00132_e0`, `rxn05495_c0`, `rxn09247_c0`, and `rxn34491_c0` (GPRs of non-exchange reactions all `MASE_RS10880`); see [MIT1002 PR #281](https://github.com/C-CoMP-STC/GEM-mit1002/pull/281)
- Replaces `rxn08722_c0` with `rxn05684_c0` and `rxn09304_c0` with `rxn09306_c0`; see [MIT1002 PR #281](https://github.com/C-CoMP-STC/GEM-mit1002/pull/281)
- Removes `EX_cpd00041_e0`, `rxn05217_c0`, `rxn05496_c0`, `rxn05297_c0`, `rxn05669_c0`, `cpd00041_e0`, and `MASE_RS07775`; see [MIT1002 PR #281](https://github.com/C-CoMP-STC/GEM-mit1002/pull/281)
- Adds `cpd00992_c0`, `cpd00992_e0`, `cpd00992_trans`, `EX_cpd0992_e0`, and `rxn01305_c0` (GPR: `MASE_RS02430 or MASE_RS06555`); see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Adds `rxn01011_c0` with GPR `MASE_RS02430 or MASE_RS06555 or MASE_RS19525 or MASE_RS09235`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Adds `mmal_sald_redox`, `rxn36075_c0`, and `rxn43611_c0` (all GPRs: `MASE_RS02430 or MASE_RS18005 or MASE_RS06835`); see MIT1002 PRs [#285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285) and [#300](https://github.com/C-CoMP-STC/GEM-mit1002/pull/300)
- Adds `rxn01013_c0` with GPR `MASE_RS02430 or MASE_RS18005 or MASE_RS06835 or MASE_RS09245 or MASE_RS14895`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Adds `rxn12191_c0` with GPR `MASE_RS02430 or MASE_RS18005 or MASE_RS06835 or MASE_RS13395 or MASE_RS11855`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Adds `rxn16141_c0` with GPR `MASE_RS02430 or MASE_RS18005 or MASE_RS06835 or MASE_RS09245`; see [MIT1002 PR #285](https://github.com/C-CoMP-STC/GEM-mit1002/pull/285)
- Removes `rxn00668_c0`, `cpd00663_c0`, and `MASE_RS11570`; see [MIT1002 PR #286](https://github.com/C-CoMP-STC/GEM-mit1002/pull/286)
- Adds `rxn00509_c0` with GPR `MASE_RS13390 or MASE_RS18975`; see [MIT1002 PR #288](https://github.com/C-CoMP-STC/GEM-mit1002/pull/288)
- Adds `cpd00334_c0`, `cpd00705_c0`, `rxn01053_c0` and `rxn02226_c0` (all GPRs: `MASE_RS13390 or MASE_RS02125`); see [MIT1002 PR #288](https://github.com/C-CoMP-STC/GEM-mit1002/pull/288)
- Adds `cpd00269_c0`, `cpd00413_c0`, `cpd16479_c0`, `rxn01802_c0` (GPR: `MASE_RS07620`), `rxn11955_c0` (GPR: `MASE_RS09110 and MASE_RS09115`), and `rxn11960_c0` (GPR: `MASE_RS09115 and MASE_RS13970`); see [MIT1002 PR #289](https://github.com/C-CoMP-STC/GEM-mit1002/pull/289)
- Removes `rxn02222_c0`, `cpd00703_c0`, and `cpd01747_c0`; see [MIT1002 PR #293](https://github.com/C-CoMP-STC/GEM-mit1002/pull/293)
- Adds `rxn05894_c0` with GPR `MASE_RS15795`; see [MIT1002 PR #299](https://github.com/C-CoMP-STC/GEM-mit1002/pull/299)
- Removes `rxn00569_c0`; see [MIT1002 PR #299](https://github.com/C-CoMP-STC/GEM-mit1002/pull/299)
- Adds `cpd30760_c0`, `cpd30760_e0`, and `EX_cpd30760_e0`; see [MIT1002 PR #303](https://github.com/C-CoMP-STC/GEM-mit1002/pull/303)
- Replaces `rxn08275_c0` with `rxn29147_c0` (GPR: `MASE_RS14210 and MASE_RS14215`); see [MIT1002 PR #303](https://github.com/C-CoMP-STC/GEM-mit1002/pull/303)
- Removes `EX_cpd01012_e0`, `rxn02021_c0`, `rxn05315_c0`, `rxn05517_c0`, `cpd01012_c0`, `cpd01012_e0`, `cpd00531_c0`, `cpd00965_c0`, `MASE_RS08265`, `MASE_RS14220`, `MASE_RS18035`, `MASE_RS18410`, and `MASE_RS18420`; see [MIT1002 PR #303](https://github.com/C-CoMP-STC/GEM-mit1002/pull/303)
- Replaces `rxn21859_c0` with `rxn46124_c0` and `rxn21863_c0` with `rxn45550_c0`; see [MIT1002 PR #306](https://github.com/C-CoMP-STC/GEM-mit1002/pull/306)
- Adds `rxn05039_c0` with GPR `MASE_RS00740`; see [MIT1002 PR #307](https://github.com/C-CoMP-STC/GEM-mit1002/pull/307)
- Removes `rxn00309_c0`; see [MIT1002 PR #312](https://github.com/C-CoMP-STC/GEM-mit1002/pull/312)
- Removes `rxn10289_c0`, `rxn10290_c0`, `rxn10291_c0`, `rxn10292_c0`, `rxn10293_c0`, `rxn10294_c0`, `rxn10295_c0`, `rxn10296_c0`, `rxn10297_c0`, `rxn10307_c0`, `rxn10308_c0`, `rxn10309_c0`, `rxn10312_c0`, `rxn10313_c0`, `rxn10314_c0`, `rxn10315_c0`, `cpd15728_c0`, `cpd15729_c0`, `cpd15730_c0`, `cpd15731_c0`, `cpd15732_c0`, `cpd15733_c0`, `cpd15734_c0`, `cpd15735_c0`, `cpd15736_c0`, `cpd15746_c0`, `cpd15747_c0`, `cpd15748_c0`, `cpd15749_c0`, `cpd15750_c0`, `cpd15751_c0`, `cpd15752_c0`, `cpd15753_c0`, `cpd15754_c0`, `cpd15764_c0`, `cpd15765_c0`, `cpd15766_c0`, `cpd15769_c0`, `cpd15770_c0`, `cpd15771_c0`, and `cpd15772_c0`; see [MIT1002 PR #315](https://github.com/C-CoMP-STC/GEM-mit1002/pull/315)
- Adds `rxn00452_c0` with GPR `MASE_RS17710`; see [MIT1002 PR #316](https://github.com/C-CoMP-STC/GEM-mit1002/pull/316)
- Removes `rxn00196_c0` and `rxn01032_c0`; see [MIT1002 PR #316](https://github.com/C-CoMP-STC/GEM-mit1002/pull/316)
- Adds `rxn15341_c0` with GPR `MASE_RS02430 or MASE_RS06555`; see [MIT1002 PR #317](https://github.com/C-CoMP-STC/GEM-mit1002/pull/317)

All removed genes were reciprocal best hits of genes that were removed in the indicated MIT1002 PR and had identical annotations, and all genes in the GPRs of new reactions were reciprocal best hits of genes in the GPRs of the corresponding MIT1002 reactions.

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists