### PR TITLE
Feat: add new pathway from serine to glycine

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -21580,6 +21580,21 @@
           </rdf:RDF>
         </annotation>
       </species>
+      <species metaid="meta_M_cpd08626_c0" sboTerm="SBO:0000247" id="M_cpd08626_c0" name="2-Aminomalonate semialdehyde [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C3H5NO3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_M_cpd08626_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/2amsa"/>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11822"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:2-AMINOMALONATE-SEMIALDEHYDE"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
     </listOfSpecies>
     <listOfParameters>
       <parameter sboTerm="SBO:0000626" id="cobra_default_lb" value="-1000" constant="true"/>
@@ -65756,6 +65771,55 @@
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16200"/>
         </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn46591_c0" sboTerm="SBO:0000176" id="R_rxn46591_c0" name="L-serine:NAD+ 3-oxidoreductase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn46591_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R10985"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-16007"/>
+                  <rdf:li rdf:resource="https://identifiers.org/ec-code/1.1.1.387"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd00054_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00003_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd08626_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00004_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <fbc:geneProductAssociation>
+          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15535"/>
+        </fbc:geneProductAssociation>
+      </reaction>
+      <reaction metaid="meta_R_rxn04645_c0" sboTerm="SBO:0000176" id="R_rxn04645_c0" name="Spontaneous decarboxylation of 2-aminomalonate semialdehyde [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#meta_R_rxn04645_c0">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R06830"/>
+                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-16002"/>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference species="M_cpd08626_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_cpd00011_c0" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_cpd04122_c0" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
     </listOfReactions>
     <fbc:listOfObjectives fbc:activeObjective="obj">


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Adds new metabolite `cpd08626_c0`: 2-Aminomalonate semialdehyde
- Adds `rxn46591_c0`: L-Serine + NAD<sup>+</sup> <=> 2-Aminomalonate semialdehyde + NADH + H<sup>+</sup>, GPR: `MASE_RS15535`
- Adds `rxn04645_c0`: 2-Aminomalonate semialdehyde + H<sup>+</sup> => Aminoacetaldehyde + CO<sub>2</sub> (no GPR)

The reciprocal best BLAST hit of `MASE_RS15535` in the MIT1002 genome is a pseudogene, and no other genes in the MIT1002 genome were annotated with the same E.C. number (1.1.1.387), so this alternate pathway for converting serine into glycine seems to be unique to the ATCC27126 and HOT1A3 strains. `rxn04645_c0` is spontaneous according to [KEGG](https://www.genome.jp/entry/1.1.1.387), hence the empty GPR. These changes also resolve the dead-end at `cpd04122_c0`/`rxn05735_c0` (aminoacetaldehyde).

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists