### PR TITLE
Fix: remove unsubstantiated differences from HOT1A3 and MIT1002 models

### DIFF
--- a/model.xml
+++ b/model.xml
@@ -7307,25 +7307,6 @@
           </rdf:RDF>
         </annotation>
       </species>
-      <species metaid="meta_M_cpd00770_c0" sboTerm="SBO:0000247" id="M_cpd00770_c0" name="N-Formyl-L-glutamate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C6H7NO5">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00770_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00770"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C6H9NO5/c8-3-7-4(6(11)12)1-2-5(9)10/h3-4H,1-2H2,(H,7,8)(H,9,10)(H,11,12)/p-2/t4-/m0/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/ADZLWSMFHHHOBV-BYPYZUCNSA-L"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/Nforglu"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01045"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1287"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:FORMYL-GLU"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
       <species metaid="meta_M_cpd00957_c0" sboTerm="SBO:0000247" id="M_cpd00957_c0" name="2,5-Diamino-6-(5&apos;-phosphoribosylamino)-4-pyrimidineone [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-2" fbc:chemicalFormula="C9H14N5O8P">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -7379,44 +7360,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00186"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM179"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:L-LACTATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd01669_c0" sboTerm="SBO:0000247" id="M_cpd01669_c0" name="Estrone 3-sulfate [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="-1" fbc:chemicalFormula="C18H21O5S">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd01669_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd01669"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C18H22O5S/c1-18-9-8-14-13-5-3-12(23-24(20,21)22)10-11(13)2-4-15(14)16(18)6-7-17(18)19/h3,5,10,14-16H,2,4,6-9H2,1H3,(H,20,21,22)/p-1/t14-,15-,16+,18+/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/JKKFKPJIXZFSSB-CBZIJGRNSA-M"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/estrones"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02538"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1230"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ESTRONE-SULFATE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd00362_c0" sboTerm="SBO:0000247" id="M_cpd00362_c0" name="Estrone [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="0" fbc:chemicalFormula="C18H22O2">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd00362_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd00362"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C18H22O2/c1-18-9-8-14-13-5-3-12(19)10-11(13)2-4-15(14)16(18)6-7-17(18)20/h3,5,10,14-16,19H,2,4,6-9H2,1H3/t14-,15-,16+,18+/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/DNXHEGUUPJUMQT-CBZIJGRNSA-N"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/estrone"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00468"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM327"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:ESTRONE"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -10930,25 +10873,6 @@
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00455"/>
                   <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM355"/>
                   <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NICOTINAMIDE_NUCLEOTIDE"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </species>
-      <species metaid="meta_M_cpd02016_c0" sboTerm="SBO:0000247" id="M_cpd02016_c0" name="N-Ribosylnicotinamide [c0]" compartment="c0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false" fbc:charge="1" fbc:chemicalFormula="C11H15N2O5">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_M_cpd02016_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.compound/cpd02016"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchi/InChI=1S/C11H14N2O5/c12-10(17)6-2-1-3-13(4-6)11-9(16)8(15)7(5-14)18-11/h1-4,7-9,11,14-16H,5H2,(H-,12,17)/p+1/t7-,8-,9-,11-/m1/s1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/inchikey/JLEBZPBDRKPWTD-TURQNECASA-O"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.metabolite/rnam"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03150"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1115"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:NICOTINAMIDE_RIBOSE"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26312,39 +26236,6 @@
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11185"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn01102_c0" sboTerm="SBO:0000176" id="R_rxn01102_c0" name="ATP:(R)-glycerate 3-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01102_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01102"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GLYCK"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R01514"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/23519"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/23517"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100328"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR141891"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:GLY3KIN-RXN"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/2.7.1.31"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00002_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00223_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00008_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00169_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS15135"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00100_c0" sboTerm="SBO:0000176" id="R_rxn00100_c0" name="ATP:dephospho-CoA 3&apos;-phosphotransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -28794,35 +28685,6 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn00375_c0" sboTerm="SBO:0000176" id="R_rxn00375_c0" name="N-Formyl-L-glutamate amidohydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00375_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00375"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NFORGLUAH"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00525"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/12479"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101945"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.1.68"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00770_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00023_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00047_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS12045"/>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn00300_c0" sboTerm="SBO:0000176" id="R_rxn00300_c0" name="GTP 7,8-8,9-dihydrolase (diphosphate-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -28920,37 +28782,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS17475"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn02798_c0" sboTerm="SBO:0000176" id="R_rxn02798_c0" name="Estrone 3-sulfate sulfohydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn02798_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn02798"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R03980"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/31058"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR108566"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-14263"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.6.1"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.6.2"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd01669_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00048_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00067_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00362_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16745"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00999_c0" sboTerm="SBO:0000176" id="R_rxn00999_c0" name="Phenylpyruvate:oxygen oxidoreductase (hydroxylating,decarboxylating) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -31687,7 +31518,10 @@
           <speciesReference species="M_cpd00288_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18525"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18525"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13815"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn03435_c0" sboTerm="SBO:0000176" id="R_rxn03435_c0" name="(R)-2,3-Dihydroxy-3-methylpentanoate:NADP+ oxidoreductase (isomerizing) [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -33716,35 +33550,6 @@
           </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_rxn08599_c0" sboTerm="SBO:0000176" id="R_rxn08599_c0" name="GDP-mannose mannosyl hydrolase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn08599_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn08599"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/GDPMNH"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR100091"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00083_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00031_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00138_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:or>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16580"/>
-            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS16580"/>
-          </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
       <reaction metaid="meta_R_rxn05034_c0" sboTerm="SBO:0000176" id="R_rxn05034_c0" name="solanesyl-diphosphate:4-hydroxybenzoate nonaprenyltransferase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -34636,38 +34441,6 @@
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS18005"/>
             <fbc:geneProductRef fbc:geneProduct="G_MASE_RS06835"/>
           </fbc:or>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn01670_c0" sboTerm="SBO:0000176" id="R_rxn01670_c0" name="Nicotinamide ribonucleotide phosphohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn01670_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn01670"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NIRP"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/NMNR"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R02323"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/30816"/>
-                  <rdf:li rdf:resource="https://identifiers.org/rhea/30818"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR101970"/>
-                  <rdf:li rdf:resource="https://identifiers.org/biocyc/META:RXN-5841"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.1.3.5"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00355_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00009_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd02016_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS02790"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01706_c0" sboTerm="SBO:0000176" id="R_rxn01706_c0" name="dUTP:cytidine 5&apos;-phosphotransferase [c0]" reversible="true" fast="false" fbc:lowerFluxBound="cobra_default_lb" fbc:upperFluxBound="cobra_default_ub">
@@ -39659,34 +39432,6 @@
         </listOfProducts>
         <fbc:geneProductAssociation>
           <fbc:geneProductRef fbc:geneProduct="G_MASE_RS00945"/>
-        </fbc:geneProductAssociation>
-      </reaction>
-      <reaction metaid="meta_R_rxn00552_c0" sboTerm="SBO:0000176" id="R_rxn00552_c0" name="D-glucosamine-6-phosphate aminohydrolase (ketol isomerizing) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_R_rxn00552_c0">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/seed.reaction/rxn00552"/>
-                  <rdf:li rdf:resource="https://identifiers.org/bigg.reaction/G6PDA"/>
-                  <rdf:li rdf:resource="https://identifiers.org/kegg.reaction/R00765"/>
-                  <rdf:li rdf:resource="https://identifiers.org/metanetx.reaction/MNXR138459"/>
-                  <rdf:li rdf:resource="https://identifiers.org/ec-code/3.5.99.6"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-        <listOfReactants>
-          <speciesReference species="M_cpd00001_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00288_c0" stoichiometry="1" constant="true"/>
-        </listOfReactants>
-        <listOfProducts>
-          <speciesReference species="M_cpd00013_c0" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_cpd00072_c0" stoichiometry="1" constant="true"/>
-        </listOfProducts>
-        <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS13815"/>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn01639_c0" sboTerm="SBO:0000176" id="R_rxn01639_c0" name="N-Formimino-L-glutamate formiminohydrolase [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -49676,7 +49421,10 @@
           <speciesReference species="M_cpd00082_c0" stoichiometry="1" constant="true"/>
         </listOfProducts>
         <fbc:geneProductAssociation>
-          <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08045"/>
+          <fbc:or>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS08045"/>
+            <fbc:geneProductRef fbc:geneProduct="G_MASE_RS11295"/>
+          </fbc:or>
         </fbc:geneProductAssociation>
       </reaction>
       <reaction metaid="meta_R_rxn00851_c0" sboTerm="SBO:0000176" id="R_rxn00851_c0" name="D-alanine:D-alanine ligase (ADP-forming) [c0]" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -68183,19 +67931,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS15135" sboTerm="SBO:0000243" fbc:id="G_MASE_RS15135" fbc:name="MASE_RS15135" fbc:label="G_MASE_RS15135">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS15135">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950614.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS14025" sboTerm="SBO:0000243" fbc:id="G_MASE_RS14025" fbc:name="MASE_RS14025" fbc:label="G_MASE_RS14025">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -69067,19 +68802,6 @@
           </rdf:RDF>
         </annotation>
       </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS12045" sboTerm="SBO:0000243" fbc:id="G_MASE_RS12045" fbc:name="MASE_RS12045" fbc:label="G_MASE_RS12045">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS12045">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_232362759.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
       <fbc:geneProduct metaid="meta_G_MASE_RS00680" sboTerm="SBO:0000243" fbc:id="G_MASE_RS00680" fbc:name="MASE_RS00680" fbc:label="G_MASE_RS00680">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
@@ -69126,19 +68848,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014951029.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16745" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16745" fbc:name="MASE_RS16745" fbc:label="G_MASE_RS16745">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS16745">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014950896.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -70400,19 +70109,6 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/refseq/WP_014947964.1"/>
-                </rdf:Bag>
-              </bqbiol:is>
-            </rdf:Description>
-          </rdf:RDF>
-        </annotation>
-      </fbc:geneProduct>
-      <fbc:geneProduct metaid="meta_G_MASE_RS16580" sboTerm="SBO:0000243" fbc:id="G_MASE_RS16580" fbc:name="MASE_RS16580" fbc:label="G_MASE_RS16580">
-        <annotation>
-          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-            <rdf:Description rdf:about="#meta_G_MASE_RS16580">
-              <bqbiol:is>
-                <rdf:Bag>
-                  <rdf:li rdf:resource="https://identifiers.org/refseq/WP_041693573.1"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>


### PR DESCRIPTION
#### Main improvements in this PR:

This pull request:

- Removes reaction `rxn00375_c0`: N-Formylglutamine + H<sub>2</sub>O <=> Glutamate + Formate, GPR: `MASE_RS12045`
- Removes `rxn00552_c0`: D-Glucosamine phosphate + H<sub>2</sub>O <=> D-fructose-6-phosphate + NH<sub>3</sub>, GPR: `MASE_RS13815`
- Removes reaction `rxn01102_c0`: Glycerate + ATP --> 3-Phosphoglycerate + ADP + H<sup>+</sup>, GPR: `MASE_RS15135`
- Removes reaction `rxn01670_c0`: Nicotinamide ribonucleotide + H<sub>2</sub>O <=> N-Ribosylnicotinamide + Phosphate, GPR: `MASE_RS02790`
- Removes reaction `rxn02798_c0`: Estrone 3-sulfate + H<sub>2</sub>O <=> Estrone + Sulfate + H<sup>+</sup>, GPR: `MASE_RS16745`
- Removes reaction `rxn08599_c0`: GDP-mannose + H<sub>2</sub>O <=> D-Mannose + GDP, GPR: `MASE_RS16580`
- Removes metabolite `cpd00362_c0`: Estrone
- Removes metabolite `cpd00770_c0`: N-Formyl-glutamine
- Removes metabolite `cpd01669_c0`: Estrone-3 sulfate
- Removes metabolite `cpd02016_c0`: N-Ribosylnicotinamide
- Removes genes `MASE_RS12045`, `MASE_RS15135`, `MASE_RS16580`, and `MASE_RS16745` from the model
- Changes the GPR of `rxn00555_c0` from `MASE_RS18525` to `MASE_RS18525 or MASE_RS13815`
- Changes the GPR of `rxn00629_c0` from `MASE_RS08045` to `MASE_RS08045 or MASE_RS11295`

All of these reactions and metabolites are dead-ends, so removing them won’t affect the model’s predicted fluxes in any way. All of these were also reactions and metabolites that weren’t also in both the MIT1002 and HOT1A3 models, so removing them clarifies which differences in the three strains’ metabolism we actually have evidence for.

Neither `MASE_RS16745` nor `MASE_RS16580` were annotated with any E.C. numbers, no other genes were annotated with appropriate E.C. numbers for `rxn00375_c0` (3.1.6.1) or `rxn02798_c0` (I actually can’t find any appropriate E.C. numbers for this reaction), and no other reactions involved either estrone-3-sulfate (`cpd01669_c0`) or estrone (`cpd00362_c0`).

`MASE_RS13815` is currently the only gene in the GPR of `rxn00552_c0`, but was only annotated with the E.C. number for `rxn00555_c0` (2.6.1.16), and no genes were annotated with the E.C. number for `rxn00552_c0` (3.5.99.6). `rxn00555_c0` is already in all three strains’ models.

`MASE_RS15135` was annotated as a restriction enzyme, and no other genes were annotated with the E.C. number for `rxn01102_c0` (2.7.1.31).

`MASE_RS02790` was annotated with E.C.s 3.6.1.45 and 3.1.3.5, but [KEGG has a comment for 3.6.1.45](https://www.genome.jp/entry/3.6.1.45) saying that some but not all enzymes of this class also appear to have 5’-nucleotidase (see EC 3.1.3.5) activity”. Since N-Ribosylnicotinamide doesn’t participate in any reactions other than `rxn01670_c0`, I’m not seeing much reason to believe that `MASE_RS02790` actually has broad-specificity 5’-nucleotidase activity (i.e. can catalyze `rxn01670_c0`). `rxn01670_c0` is currently in the HOT1A3 and ATCC27126 models but not the MIT1002 model.

`MASE_RS12045` was annotated with 3.5.2.6, which is hydrolysis of β-lactams, which is definitely not what `rxn00375_c0` represents. No other genes were annotated with the appropriate E.C. number for `rxn00375_c0` (3.5.1.68), and no other reactions involve N-formylglutamine (`cpd00770_c0`).

`MASE_RS11295` is the reciprocal best BLAST hit of `WP_049589016.1`; see [MIT1002 PR #339](https://github.com/C-CoMP-STC/GEM-mit1002/pull/339).

**I hereby confirm that I have:**
- [X] Made my edits to the model on the XML file
- [ ] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
- [ ] Any removed reactions and metabolites have been moved to the corresponding deprecated identifier lists